### PR TITLE
Move installation-unique asset dir to user cache

### DIFF
--- a/molmo_spaces/grasp_generation/pipeline/articulation_test.py
+++ b/molmo_spaces/grasp_generation/pipeline/articulation_test.py
@@ -14,7 +14,7 @@ from scipy.spatial.transform import Rotation as R
 from sklearn.cluster import MiniBatchKMeans
 from tqdm import tqdm
 
-from molmo_spaces.molmo_spaces_constants import ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR
+from molmo_spaces.molmo_spaces_constants import ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR, ASSETS_DIR
 
 
 def rotation_matrix_from_axis_angle(axis, angle):
@@ -788,7 +788,7 @@ def main_single_file_filtering(
         return 0, None
 
     xml_content = ET.tostring(root, encoding="unicode")
-    robot_xml_path = f"{ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR}/assets/robots/floating_robotiq/model_articulate.xml"
+    robot_xml_path = str(ASSETS_DIR / "robots/floating_robotiq/model_articulate.xml")
 
     with open(robot_xml_path, "r") as f:
         robot_xml_content = f.read()

--- a/molmo_spaces/grasp_generation/pipeline/perturbations_test.py
+++ b/molmo_spaces/grasp_generation/pipeline/perturbations_test.py
@@ -13,7 +13,7 @@ from scipy.spatial.transform import Rotation as R
 from sklearn.cluster import MiniBatchKMeans
 from tqdm import tqdm
 
-from molmo_spaces.molmo_spaces_constants import ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR
+from molmo_spaces.molmo_spaces_constants import ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR, ASSETS_DIR
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--object_name", type=str)
@@ -149,7 +149,7 @@ def test_single_grasp(grasp_data, object_name, model=None, data=None, viewer=Non
         include = ET.Element("include", {"file": args.xml_file})
         root.append(include)
         xml_content = ET.tostring(root, encoding="unicode")
-        gripper_xml_path = f"{ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR}/assets/robots/floating_robotiq/model_rigid.xml"
+        gripper_xml_path = str(ASSETS_DIR / "robots/floating_robotiq/model_rigid.xml")
         with open(gripper_xml_path, "r") as f:
             additional_xml_content = f.read()
         xml_content = merge_xml_contents(xml_content, additional_xml_content)
@@ -604,9 +604,7 @@ if __name__ == "__main__":
     include = ET.Element("include", {"file": args.xml_file})
     root.append(include)
     xml_content = ET.tostring(root, encoding="unicode")
-    gripper_xml_path = (
-        f"{ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR}/assets/robots/floating_robotiq/model_rigid.xml"
-    )
+    gripper_xml_path = str(ASSETS_DIR / "robots/floating_robotiq/model_rigid.xml")
     with open(gripper_xml_path, "r") as f:
         additional_xml_content = f.read()
     xml_content = merge_xml_contents(xml_content, additional_xml_content)

--- a/molmo_spaces/grasp_generation/robotiq_gripper.py
+++ b/molmo_spaces/grasp_generation/robotiq_gripper.py
@@ -2,7 +2,7 @@ import numpy as np
 import trimesh
 import trimesh.transformations as tra
 
-from molmo_spaces.molmo_spaces_constants import ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR
+from molmo_spaces.molmo_spaces_constants import ASSETS_DIR
 
 
 class RobotiqGripper:
@@ -22,14 +22,8 @@ class RobotiqGripper:
         self.q = q
         gripping_center = 0.155
         self.tcp_offset = np.array([0, 0, gripping_center])
-        fn_base = (
-            root_folder
-            + f"{ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR}/assets/robots/floating_robotiq/assets/hand.stl"
-        )
-        fn_finger = (
-            root_folder
-            + f"{ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR}/assets/robots/floating_robotiq/assets/finger.stl"
-        )
+        fn_base = root_folder + str(ASSETS_DIR / "robots/floating_robotiq/assets/hand.stl")
+        fn_finger = root_folder + str(ASSETS_DIR / "robots/floating_robotiq/assets/finger.stl")
         self.base = trimesh.load(fn_base)
         self.finger_l = trimesh.load(fn_finger)
         self.finger_r = self.finger_l.copy()

--- a/molmo_spaces/molmo_spaces_constants.py
+++ b/molmo_spaces/molmo_spaces_constants.py
@@ -5,6 +5,7 @@ Overwrite in the environment with e.g.:
     MLSPACES_ASSETS_DIR=/Users/username/mlspaces_resources mjpython scripts/...
 """
 
+import base64
 import itertools
 import json
 import logging
@@ -55,8 +56,19 @@ ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR = Path(__file__).resolve().parent.parent
 _DATA_CACHE_DEFAULT = Path("~/.cache/molmo-spaces-resources").expanduser()
 DATA_CACHE_DIR = Path(os.environ.get("MLSPACES_CACHE_DIR", _DATA_CACHE_DEFAULT))
 
+# Each molmospaces installation needs its own assets directory.
+# The default ASSETS_DIR will be in the user's cache directory,
+# but uses a unique hash of the installation path to avoid conflicts.
+_install_hash = (
+    base64.urlsafe_b64encode(str(ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR).encode())
+    .decode()
+    .rstrip("=")
+)
 ASSETS_DIR = Path(
-    os.environ.get("MLSPACES_ASSETS_DIR", ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR / "assets")
+    os.environ.get(
+        "MLSPACES_ASSETS_DIR",
+        Path.home() / ".cache" / "molmospaces" / "assets" / _install_hash,
+    )
 )
 ROBOTS_DIR = ASSETS_DIR / "robots"
 OBJAVERSE_ASSETS_DIR = Path(
@@ -217,7 +229,7 @@ def get_scenes_root():
             _SCENES_ROOT = Path(
                 os.environ.get(
                     "MLSPACES_SCENES_ROOT",
-                    ABS_PATH_OF_TOP_LEVEL_MOLMO_SPACES_DIR / "assets" / "scenes",
+                    ASSETS_DIR / "scenes",
                 )
             )
         print(f"Using SCENES_ROOT: {_SCENES_ROOT}")


### PR DESCRIPTION
Previously, when molmospaces was used as a project dependency, this would place the `assets` folder in the user's virtualenv's `site-packages` directory, which is obviously suboptimal. Now, it gets a unique subdir (specified by hash of molmospaces installation path) of `~/.cache/molmospaces/assets`.