### PR TITLE
Add autogenerated docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install UV package manager
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+
+      - name: Create virtual environment
+        run: uv venv --python 3.11
+
+      - name: Install docs dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install \
+            "mkdocs>=1.6.0" \
+            "mkdocs-material>=9.5.0" \
+            "mkdocstrings[python]>=0.27.0" \
+            "mkdocs-autorefs>=1.2.0" \
+            "mkdocs-git-revision-date-localized-plugin"
+
+      - name: Install package (no heavy deps, for static analysis)
+        run: |
+          source .venv/bin/activate
+          uv pip install -e . --no-deps
+
+      - name: Build and deploy to gh-pages
+        run: |
+          source .venv/bin/activate
+          mkdocs gh-deploy --force --clean

--- a/docs/api/controllers.md
+++ b/docs/api/controllers.md
@@ -1,0 +1,6 @@
+# controllers
+
+::: molmo_spaces.controllers
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/env.md
+++ b/docs/api/env.md
@@ -1,0 +1,6 @@
+# env
+
+::: molmo_spaces.env
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/evaluation.md
+++ b/docs/api/evaluation.md
@@ -1,0 +1,6 @@
+# evaluation
+
+::: molmo_spaces.evaluation
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,18 @@
+# API Reference
+
+Auto-generated documentation for the `molmo_spaces` Python package.
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| [molmo_spaces](molmo_spaces.md) | Top-level package and constants |
+| [env](env.md) | Simulation environment base classes |
+| [tasks](tasks.md) | Task definitions and reward functions |
+| [robots](robots.md) | Robot models and configurations |
+| [controllers](controllers.md) | Robot controllers (IK, impedance, etc.) |
+| [kinematics](kinematics.md) | Kinematic utilities and solvers |
+| [renderer](renderer.md) | Rendering backends and camera utilities |
+| [policy](policy.md) | Policy interfaces and wrappers |
+| [evaluation](evaluation.md) | Evaluation metrics and protocols |
+| [utils](utils.md) | Shared utilities |

--- a/docs/api/kinematics.md
+++ b/docs/api/kinematics.md
@@ -1,0 +1,6 @@
+# kinematics
+
+::: molmo_spaces.kinematics
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/molmo_spaces.md
+++ b/docs/api/molmo_spaces.md
@@ -1,0 +1,8 @@
+# molmo_spaces
+
+::: molmo_spaces
+    options:
+      members_order: alphabetical
+      show_submodules: false
+
+::: molmo_spaces.molmo_spaces_constants

--- a/docs/api/policy.md
+++ b/docs/api/policy.md
@@ -1,0 +1,6 @@
+# policy
+
+::: molmo_spaces.policy
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -1,0 +1,6 @@
+# renderer
+
+::: molmo_spaces.renderer
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/robots.md
+++ b/docs/api/robots.md
@@ -1,0 +1,6 @@
+# robots
+
+::: molmo_spaces.robots
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -1,0 +1,6 @@
+# tasks
+
+::: molmo_spaces.tasks
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,6 @@
+# utils
+
+::: molmo_spaces.utils
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# MolmoSpaces
+
+**Large-scale assets and benchmarks for vision-language policies.**
+
+## Overview
+
+MolmoSpaces is a large-scale simulation environment and benchmark suite for training and evaluating vision-language policies in robotics. It provides:
+
+- High-fidelity 3D asset libraries (objects, environments, robots)
+- Multi-simulator support (MuJoCo, Isaac Sim, ManiSkill)
+- Standardized evaluation protocols for vision-language policies
+- Data generation pipelines for imitation learning
+
+## Quick Links
+
+| Resource | Description |
+|----------|-------------|
+| [Assets](assets.md) | Asset management and resource usage |
+| [Data Format](data_format.md) | Episode and observation data specifications |
+| [Data Processing](data_processing.md) | Preprocessing and postprocessing pipelines |
+| [Code Structure](code_structure.md) | Repository layout and module organization |
+| [Development](development.md) | Contributing guidelines and tooling setup |
+| [API Reference](api/index.md) | Auto-generated Python API documentation |
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/allenai/molmospaces.git
+cd molmospaces
+
+# Install with uv (recommended)
+uv pip install -e ".[mujoco]"
+```
+
+See the [README on GitHub](https://github.com/allenai/molmospaces#readme) for full installation instructions including conda setup and optional dependency groups.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,104 @@
+site_name: MolmoSpaces
+site_description: Large scale assets and benchmarks for vision language policies
+site_url: https://allenai.github.io/molmospaces
+repo_url: https://github.com/allenai/molmospaces
+repo_name: allenai/molmospaces
+edit_uri: edit/main/docs/
+copyright: Copyright &copy; 2026 Allen Institute for Artificial Intelligence
+
+theme:
+  name: material
+  logo: images/MolmoSpacesLogo.png
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+    - content.action.edit
+    - toc.follow
+
+nav:
+  - Home: index.md
+  - Guides:
+      - Assets: assets.md
+      - Data Format: data_format.md
+      - Data Processing: data_processing.md
+      - Code Structure: code_structure.md
+      - Development: development.md
+  - API Reference:
+      - Overview: api/index.md
+      - molmo_spaces: api/molmo_spaces.md
+      - env: api/env.md
+      - tasks: api/tasks.md
+      - robots: api/robots.md
+      - controllers: api/controllers.md
+      - kinematics: api/kinematics.md
+      - renderer: api/renderer.md
+      - policy: api/policy.md
+      - evaluation: api/evaluation.md
+      - utils: api/utils.md
+
+plugins:
+  - search
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: timeago
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [.]
+          options:
+            docstring_style: google
+            docstring_section_style: table
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            merge_init_into_class: true
+            show_submodules: false
+            allow_inspection: false
+            preload_modules: []
+            inherited_members: true
+            show_if_no_docstring: true
+            show_root_toc_entry: true
+            summary: true
+            # type annotation display
+            separate_signature: true
+            show_signature_annotations: true
+            annotations_path: brief
+            signature_crossrefs: true
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,13 @@ mujoco = [
 mujoco-filament = [
     "mujoco @ file://${PROJECT_ROOT}/bin/wheels/mujoco-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
 ]
+docs = [
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocstrings[python]>=0.27.0",
+    "mkdocs-autorefs>=1.2.0",
+    "mkdocs-git-revision-date-localized-plugin",
+]
 
 [build-system]
 requires = ["setuptools", "wheel"]


### PR DESCRIPTION
Use `mkdocs` to autogenerate documentation as a static website, and a GH action to publish upon commits to `main`.