### PR TITLE
Unify policy constructors and usages

### DIFF
--- a/mlspaces_tests/data_generation/generate_test_data_pick.py
+++ b/mlspaces_tests/data_generation/generate_test_data_pick.py
@@ -67,7 +67,7 @@ def generate_test_data_for_config(config_orig, config_name: str):
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
     policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)  # Policy takes (config, task)
+    policy = policy_cls(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/generate_test_data_pick_and_place.py
+++ b/mlspaces_tests/data_generation/generate_test_data_pick_and_place.py
@@ -71,7 +71,7 @@ def generate_test_data_for_config(config, config_name: str):
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
     policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)  # Policy takes (config, task)
+    policy = policy_cls(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/generate_test_data_rum_open_close.py
+++ b/mlspaces_tests/data_generation/generate_test_data_rum_open_close.py
@@ -66,7 +66,7 @@ def generate_test_data_for_rum_open():
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
     policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)  # Policy takes (config, task)
+    policy = policy_cls(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations
@@ -139,7 +139,7 @@ def generate_test_data_for_rum_close():
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
     policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)  # Policy takes (config, task)
+    policy = policy_cls(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/generate_test_data_rum_pick.py
+++ b/mlspaces_tests/data_generation/generate_test_data_rum_pick.py
@@ -67,7 +67,7 @@ def generate_test_data_for_rum():
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
     policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)  # Policy takes (config, task)
+    policy = policy_cls(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/molmo_spaces/configs/policy_configs.py
+++ b/molmo_spaces/configs/policy_configs.py
@@ -29,7 +29,9 @@ except (ImportError, RuntimeError):
 class BasePolicyConfig(Config):
     """Base configuration for policies."""
 
-    policy_cls: type[BasePolicy]
+    policy_cls: type[
+        BasePolicy
+    ]  # unless pre-instantiated before eval/datagen, should take (config, task) in constructor
     policy_type: str  # Type of the policy, e.g., "planner", "teleop", "learned", etc.
 
 

--- a/molmo_spaces/evaluation/eval_main.py
+++ b/molmo_spaces/evaluation/eval_main.py
@@ -666,12 +666,6 @@ def run_evaluation(
             }
         )
 
-    # Create or use provided policy
-    if preloaded_policy is not None:
-        policy = preloaded_policy
-    else:
-        policy = exp_config.policy_config.policy_cls(exp_config, exp_config.task_type)
-
     # # Run evaluation
     # runner = JsonEvalRunner(exp_config, benchmark_dir)
     # success_count, total_count = runner.run(preloaded_policy=policy)
@@ -680,7 +674,7 @@ def run_evaluation(
     # Only pass preloaded policy for single-worker mode. With multiple workers,
     # each worker must create its own connection (WebSocket/msgpack can't be pickled).
     runner = JsonEvalRunner(exp_config, benchmark_dir)
-    success_count, total_count = runner.run(preloaded_policy=policy)
+    success_count, total_count = runner.run(preloaded_policy=preloaded_policy)
 
     # Collect per-episode results
     episode_results = collect_episode_results(resolved_output_dir)

--- a/molmo_spaces/policy/base_policy.py
+++ b/molmo_spaces/policy/base_policy.py
@@ -100,9 +100,8 @@ class PlannerPolicy(BasePolicy):
 
 
 class InferencePolicy(BasePolicy):
-    def __init__(self, config: "MlSpacesExpConfig", task_type) -> None:
+    def __init__(self, config: "MlSpacesExpConfig") -> None:
         super().__init__(config)
-        self.task_type = task_type
 
         # TODO(max): remove these (added to silence warnings)
         self.target_poses = {"grasp": np.eye(4)}
@@ -143,7 +142,7 @@ class InferencePolicy(BasePolicy):
 
     def get_info(self) -> dict:
         info = super().get_info()
-        info["task_type"] = self.task_type
+        info["task_type"] = self.config.task_type
         info["timestamp"] = time.time()
         return info
 

--- a/molmo_spaces/policy/dummy_policy.py
+++ b/molmo_spaces/policy/dummy_policy.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from molmo_spaces.policy.base_policy import NONE_PHASE, BasePolicy
-from molmo_spaces.tasks.task import BaseMujocoTask
 
 if TYPE_CHECKING:
     from molmo_spaces.configs.abstract_exp_config import MlSpacesExpConfig
@@ -18,7 +17,8 @@ class DummyPolicy(BasePolicy):
     def type(self):
         return "dummy"
 
-    def __init__(self, config: "MlSpacesExpConfig", task: BaseMujocoTask | None = None) -> None:
+    def __init__(self, config: "MlSpacesExpConfig") -> None:
+        super().__init__(config)
         self.config = config
         # Required attributes for sensors that expect a policy with target poses
         self.target_poses = {"grasp": np.eye(4)}
@@ -45,9 +45,8 @@ class DummyPolicy(BasePolicy):
 class BrownianMotionPolicy(DummyPolicy):
     """Policy that applies Gaussian noise increments over noop control, resulting in Brownian motion."""
 
-    def __init__(self, config: "MlSpacesExpConfig", task: BaseMujocoTask | None = None) -> None:
-        super().__init__(config, task)
-        self.task = task
+    def __init__(self, config: "MlSpacesExpConfig") -> None:
+        super().__init__(config)
         self.std = config.policy_config.std
 
     def get_action(self, observation) -> dict:

--- a/molmo_spaces/policy/learned_policy/cap_policy.py
+++ b/molmo_spaces/policy/learned_policy/cap_policy.py
@@ -30,10 +30,8 @@ class CAP_Policy(InferencePolicy):
     def __init__(
         self,
         exp_config: MlSpacesExpConfig,
-        task_type: str,
     ) -> None:
-        super().__init__(exp_config, exp_config.task_type)
-        self.task_type = task_type
+        super().__init__(exp_config)
         self.remote_config = exp_config.policy_config.remote_config
         self.grasping_type = exp_config.policy_config.grasping_type
         self.grasping_threshold = exp_config.policy_config.grasping_threshold
@@ -97,7 +95,7 @@ class CAP_Policy(InferencePolicy):
                     object_name=self.task.config.task_config.referral_expressions[
                         "pickup_obj_name"
                     ],
-                    task=self.task_type,
+                    task=self.config.task_type,
                 )
                 if self.use_exo:
                     K = np.array(obs["sensor_param_exo_camera_1"]["intrinsic_cv"])

--- a/molmo_spaces/policy/learned_policy/dreamzero_policy.py
+++ b/molmo_spaces/policy/learned_policy/dreamzero_policy.py
@@ -103,9 +103,8 @@ class DreamZero_Policy(InferencePolicy):
     def __init__(
         self,
         exp_config: MlSpacesExpConfig,
-        task_type: str,
     ) -> None:
-        super().__init__(exp_config, exp_config.task_type)
+        super().__init__(exp_config)
         self.remote_config = exp_config.policy_config.remote_config
         self.checkpoint_path = exp_config.policy_config.checkpoint_path
         self.grasping_type = exp_config.policy_config.grasping_type

--- a/molmo_spaces/policy/learned_policy/keyboard_policy.py
+++ b/molmo_spaces/policy/learned_policy/keyboard_policy.py
@@ -16,9 +16,8 @@ class Keyboard_Policy(InferencePolicy):
     def __init__(
         self,
         exp_config: MlSpacesExpConfig,
-        task_type: str,
     ) -> None:
-        super().__init__(exp_config, task_type)
+        super().__init__(exp_config)
         from pynput import keyboard
 
         self.robot_type = exp_config.robot_config.name

--- a/molmo_spaces/policy/learned_policy/phone_policy.py
+++ b/molmo_spaces/policy/learned_policy/phone_policy.py
@@ -17,9 +17,8 @@ class Phone_Policy(InferencePolicy):
     def __init__(
         self,
         exp_config: MlSpacesExpConfig,
-        task_type: str,
     ) -> None:
-        super().__init__(exp_config, task_type)
+        super().__init__(exp_config)
         self.robot_type = exp_config.robot_config.name
         self.session = teledex.Session()
         self.session.start()

--- a/molmo_spaces/policy/learned_policy/pi_policy.py
+++ b/molmo_spaces/policy/learned_policy/pi_policy.py
@@ -25,9 +25,8 @@ class PI_Policy(InferencePolicy, StatefulPolicy):
     def __init__(
         self,
         exp_config: MlSpacesExpConfig,
-        task_type: str,
     ) -> None:
-        super().__init__(exp_config, exp_config.task_type)
+        super().__init__(exp_config)
         self.remote_config = exp_config.policy_config.remote_config
         self.checkpoint_path = exp_config.policy_config.checkpoint_path
         self.grasping_type = exp_config.policy_config.grasping_type

--- a/molmo_spaces/policy/learned_policy/spacemouse_policy.py
+++ b/molmo_spaces/policy/learned_policy/spacemouse_policy.py
@@ -143,9 +143,8 @@ class SpaceMouse_Policy(InferencePolicy):
     def __init__(
         self,
         exp_config: MlSpacesExpConfig,
-        task_type: str,
     ) -> None:
-        super().__init__(exp_config, task_type)
+        super().__init__(exp_config)
         self.robot_type = exp_config.robot_config.name
         self.pos_sensitivity = exp_config.policy_config.pos_sensitivity
         self.rot_sensitivity = exp_config.policy_config.rot_sensitivity

--- a/molmo_spaces/policy/learned_policy/websocket_policy.py
+++ b/molmo_spaces/policy/learned_policy/websocket_policy.py
@@ -24,8 +24,7 @@ class WebsocketPolicy(InferencePolicy):
         port: int | None = None,
         connection_timeout: float | None = None,
     ):
-        task_type = getattr(config, "task_type", "pick_and_place")
-        super().__init__(config, task_type)
+        super().__init__(config)
         self.model_name = model_name
         self._last_prompt: str | None = None
 

--- a/molmo_spaces/policy/random_policy.py
+++ b/molmo_spaces/policy/random_policy.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 from molmo_spaces.policy.base_policy import BasePolicy
-from molmo_spaces.tasks.task import BaseMujocoTask
 
 if TYPE_CHECKING:
     from molmo_spaces.configs.abstract_exp_config import MlSpacesExpConfig
@@ -16,10 +15,9 @@ class RandomPolicy(BasePolicy):
     def type(self) -> str:
         return "random"
 
-    def __init__(self, config: "MlSpacesExpConfig", task: BaseMujocoTask | None = None) -> None:
+    def __init__(self, config: "MlSpacesExpConfig") -> None:
         raise NotImplementedError  # TODO(snehal): please fix
         self.config = config
-        self.task = task
         self.action_space = action_space
 
     def reset(self) -> None:

--- a/molmo_spaces/policy/solvers/navigation/astar_planner_policy.py
+++ b/molmo_spaces/policy/solvers/navigation/astar_planner_policy.py
@@ -48,7 +48,7 @@ Some TODOs:
 
 
 class AStarPlannerPolicy(PlannerPolicy):
-    def __init__(self, config: MlSpacesExpConfig, task: BaseMujocoTask | None = None) -> None:
+    def __init__(self, config: MlSpacesExpConfig, task: BaseMujocoTask) -> None:
         super().__init__(config, task)
 
         self._target_pos_quat = None

--- a/molmo_spaces/policy/solvers/opening_solver.py
+++ b/molmo_spaces/policy/solvers/opening_solver.py
@@ -12,7 +12,7 @@ from scipy.spatial.transform import Rotation as R
 from molmo_spaces.configs.abstract_exp_config import MlSpacesExpConfig
 from molmo_spaces.planner.curobo_planner import CuroboPlanner
 from molmo_spaces.policy.solvers.curobo_planner_policy import CuroboPlannerPolicy
-from molmo_spaces.tasks.opening_tasks import DoorOpeningTask
+from molmo_spaces.tasks.task import BaseMujocoTask
 from molmo_spaces.utils.curobo_utils import MotionGenStatus
 from molmo_spaces.utils.mj_model_and_data_utils import descendant_geoms, geom_aabb
 from molmo_spaces.utils.pose import pose_mat_to_pos_quat
@@ -39,13 +39,8 @@ class DoorOpeningPlannerPolicy(CuroboPlannerPolicy):
     Inherits common motion planning functionality from CuroboPlannerPolicy.
     """
 
-    def __init__(
-        self,
-        config: MlSpacesExpConfig,
-        task: DoorOpeningTask | None = None,
-    ) -> None:
+    def __init__(self, config: MlSpacesExpConfig, task: BaseMujocoTask) -> None:
         super().__init__(config, task)
-        self.task = task  # Added to help IDE typing
 
         # This policy uses both planners (unlike pick-and-place which lazy-loads one)
         self.left_motion_planner = CuroboPlanner(

--- a/molmo_spaces/policy/solvers/opening_solver.py
+++ b/molmo_spaces/policy/solvers/opening_solver.py
@@ -12,7 +12,7 @@ from scipy.spatial.transform import Rotation as R
 from molmo_spaces.configs.abstract_exp_config import MlSpacesExpConfig
 from molmo_spaces.planner.curobo_planner import CuroboPlanner
 from molmo_spaces.policy.solvers.curobo_planner_policy import CuroboPlannerPolicy
-from molmo_spaces.tasks.task import BaseMujocoTask
+from molmo_spaces.tasks.opening_tasks import DoorOpeningTask
 from molmo_spaces.utils.curobo_utils import MotionGenStatus
 from molmo_spaces.utils.mj_model_and_data_utils import descendant_geoms, geom_aabb
 from molmo_spaces.utils.pose import pose_mat_to_pos_quat
@@ -39,7 +39,7 @@ class DoorOpeningPlannerPolicy(CuroboPlannerPolicy):
     Inherits common motion planning functionality from CuroboPlannerPolicy.
     """
 
-    def __init__(self, config: MlSpacesExpConfig, task: BaseMujocoTask) -> None:
+    def __init__(self, config: MlSpacesExpConfig, task: DoorOpeningTask | None = None) -> None:
         super().__init__(config, task)
 
         # This policy uses both planners (unlike pick-and-place which lazy-loads one)

--- a/scripts/datagen/eval_policy_example.py
+++ b/scripts/datagen/eval_policy_example.py
@@ -64,7 +64,8 @@ def main(args: argparse.ArgumentParser) -> None:
         / datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     )
     # exp_config.policy_config = PiPolicyConfig()
-    # policy = exp_config.policy_config.policy_cls(exp_config)
+    # policy constructor takes (config, task)
+    # policy = exp_config.policy_config.policy_cls(exp_config, None)
     # policy.prepare_model()
     policy = None
     exp_config.save_config()

--- a/scripts/datagen/run_pipeline.py
+++ b/scripts/datagen/run_pipeline.py
@@ -316,8 +316,7 @@ def main(args: argparse.ArgumentParser) -> None:
             exp_config.policy_dt_ms = 40  # More responsive for teleoperation
             exp_config.task_horizon = 1000
         exp_config.policy_config = get_policy_config(args.policy, robot=args.robot)
-        # policy constructor takes (config, task)
-        policy = exp_config.policy_config.policy_cls(exp_config, None)
+        policy = exp_config.policy_config.policy_cls(exp_config)
     elif args.policy == "planner":
         pass
     else:

--- a/scripts/datagen/run_pipeline.py
+++ b/scripts/datagen/run_pipeline.py
@@ -316,7 +316,8 @@ def main(args: argparse.ArgumentParser) -> None:
             exp_config.policy_dt_ms = 40  # More responsive for teleoperation
             exp_config.task_horizon = 1000
         exp_config.policy_config = get_policy_config(args.policy, robot=args.robot)
-        policy = exp_config.policy_config.policy_cls(exp_config)
+        # policy constructor takes (config, task)
+        policy = exp_config.policy_config.policy_cls(exp_config, None)
     elif args.policy == "planner":
         pass
     else:


### PR DESCRIPTION
Half the policies took `config, task` and the others took `config, task_type` - and the latter never really used the task type anyway.

This PR fixes this, so now the base class takes `config, task` where `task` is nullable, and `InferencePolicy` classes just pass up `None` since they don't depend on the task instance.

Additionally, `run_evaluation()` had suboptimal behavior where it would always instantiate the policy before invoking the pipeline, which necessitated instantiating the policy before the task instance was available. This is fine for inference policies, but breaks for planner policies. This PR fixes this and just passes forward the `preloaded_policy` if available, potentially deferring creation to the main callsite in the pipeline, which is invoked with the task instance.