### PR TITLE
Install expected robots on demand

### DIFF
--- a/molmo_spaces/molmo_spaces_constants.py
+++ b/molmo_spaces/molmo_spaces_constants.py
@@ -12,6 +12,7 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
+from copy import deepcopy
 
 import compress_json
 from molmospaces_resources import (
@@ -133,8 +134,17 @@ DATA_TYPE_TO_SOURCE_TO_VERSION = dict(
 _RESOURCE_MANAGER = None
 
 
-def get_resource_manager(force_post_setup: bool = False):
-    global _RESOURCE_MANAGER
+def get_resource_manager(
+    force_post_setup: bool = False, data_type_to_source_to_version: dict | None = None
+):
+    if data_type_to_source_to_version is None:
+        # save resource manager
+        global _RESOURCE_MANAGER
+        data_type_to_source_to_version = DATA_TYPE_TO_SOURCE_TO_VERSION
+    else:
+        # ignore resource manger
+        _RESOURCE_MANAGER = None
+
     if _RESOURCE_MANAGER is None:
 
         def post_setup(manager: ResourceManager):
@@ -147,7 +157,7 @@ def get_resource_manager(force_post_setup: bool = False):
                 manager.install_all_for_data_type("grasps")
             else:
                 to_install = {}
-                for scene_source in DATA_TYPE_TO_SOURCE_TO_VERSION["scenes"]:
+                for scene_source in data_type_to_source_to_version["scenes"]:
                     source_packages = manager.find_all_packages_for_source("scenes", scene_source)
                     if len(source_packages) < 10:
                         # Fully install small scene datasets
@@ -171,7 +181,7 @@ def get_resource_manager(force_post_setup: bool = False):
             if USE_HUGGING_FACE
             else R2RemoteStorage("mujoco-thor-resources"),
             symlink_dir=ASSETS_DIR,
-            versions=DATA_TYPE_TO_SOURCE_TO_VERSION,
+            versions=data_type_to_source_to_version,
             cache_dir=DATA_CACHE_DIR,
             env_prefix="MLSPACES",
             post_setup=post_setup,
@@ -564,10 +574,38 @@ def get_robot_paths() -> dict[str, Path]:
     return robot_paths
 
 
+def install_missing_source(data_type: str, missing_source: str, existing_sources: list[str]):
+    from molmospaces_resources.manager import _lock_context, LOCAL_MANIFEST_NAME
+    from molmospaces_resources.setup_utils import _get_current_install
+
+    existing_sources.append(missing_source)
+    data_type_to_source_to_version = deepcopy(DATA_TYPE_TO_SOURCE_TO_VERSION)
+    data_type_to_source_to_version[data_type] = {
+        source: DATA_TYPE_TO_SOURCE_TO_VERSION[data_type][source] for source in existing_sources
+    }
+
+    current_install = _get_current_install(ASSETS_DIR, data_type_to_source_to_version)
+    current_install[data_type][missing_source] = None
+    manifest_path = ASSETS_DIR / LOCAL_MANIFEST_NAME
+    with _lock_context(ASSETS_DIR, DATA_CACHE_DIR):
+        with open(manifest_path, "w") as f:
+            json.dump(current_install, f, indent=2)
+
+    get_resource_manager(data_type_to_source_to_version=data_type_to_source_to_version)
+
+
 def get_robot_path(robot_name) -> Path:
     """
     Return the path to the prepackaged MlSpaces robot file for the given robot name.
     """
+    robots = os.listdir(ROBOTS_DIR)
+    if robot_name not in robots:
+        logging.info(
+            f"Robot {robot_name} not found in {ROBOTS_DIR}. Attempting direct installation."
+        )
+        install_missing_source("robots", robot_name, robots)
+        assert robot_name in os.listdir(ROBOTS_DIR), f"Failed to install missing robot {robot_name}"
+
     return ROBOTS_DIR / robot_name
 
 
@@ -599,6 +637,7 @@ def print_license_info(data_type, data_source, asset_or_tar_id):
 
 
 if __name__ == "__main__":
+    get_robot_path("i2rt_yam")
     resource_manager_log_level(logging.DEBUG)
     print("Setting up resources...")
     get_resource_manager(force_post_setup=True)

--- a/molmo_spaces/molmo_spaces_constants.py
+++ b/molmo_spaces/molmo_spaces_constants.py
@@ -137,15 +137,18 @@ _RESOURCE_MANAGER = None
 def get_resource_manager(
     force_post_setup: bool = False, data_type_to_source_to_version: dict | None = None
 ):
+    # Note: This would still be effective even wíthin a specific branch in the if-else below.
+    # The scope of variables is defined before execution starts.
+    global _RESOURCE_MANAGER
+
     if data_type_to_source_to_version is None:
         # save resource manager
-        global _RESOURCE_MANAGER
+        use_global = True
         data_type_to_source_to_version = DATA_TYPE_TO_SOURCE_TO_VERSION
     else:
-        # ignore resource manger
-        _RESOURCE_MANAGER = None
+        use_global = False
 
-    if _RESOURCE_MANAGER is None:
+    if _RESOURCE_MANAGER is None or not use_global:
 
         def post_setup(manager: ResourceManager):
             if not os.environ.get("_IN_MULTIPROCESSING_CHILD") and str2bool(
@@ -174,7 +177,7 @@ def get_resource_manager(
 
         # resource_manager_log_level()
 
-        _RESOURCE_MANAGER = setup_resource_manager(
+        manager = setup_resource_manager(
             HFRemoteStorage(
                 "allenai/molmospaces", repo_prefix="mujoco", token=os.getenv("HF_TOKEN")
             )
@@ -187,6 +190,12 @@ def get_resource_manager(
             post_setup=post_setup,
             force_post_setup=force_post_setup,
         )
+
+        if use_global:
+            _RESOURCE_MANAGER = manager
+        else:
+            return manager
+
     return _RESOURCE_MANAGER
 
 
@@ -578,8 +587,14 @@ def install_missing_source(data_type: str, missing_source: str, existing_sources
     from molmospaces_resources.manager import _lock_context, LOCAL_MANIFEST_NAME
     from molmospaces_resources.setup_utils import _get_current_install
 
-    existing_sources.append(missing_source)
+    assert missing_source in DATA_TYPE_TO_SOURCE_TO_VERSION[data_type], (
+        f"{missing_source} has no version under {data_type}"
+    )
+
     data_type_to_source_to_version = deepcopy(DATA_TYPE_TO_SOURCE_TO_VERSION)
+    existing_sources = [
+        source for source in existing_sources if source in data_type_to_source_to_version[data_type]
+    ] + [missing_source]
     data_type_to_source_to_version[data_type] = {
         source: DATA_TYPE_TO_SOURCE_TO_VERSION[data_type][source] for source in existing_sources
     }
@@ -598,13 +613,16 @@ def get_robot_path(robot_name) -> Path:
     """
     Return the path to the prepackaged MlSpaces robot file for the given robot name.
     """
-    robots = os.listdir(ROBOTS_DIR)
-    if robot_name not in robots:
+    robot_dirs = os.listdir(ROBOTS_DIR)
+    if robot_name not in robot_dirs or not (ROBOTS_DIR / robot_name).is_dir():
         logging.info(
             f"Robot {robot_name} not found in {ROBOTS_DIR}. Attempting direct installation."
         )
-        install_missing_source("robots", robot_name, robots)
-        assert robot_name in os.listdir(ROBOTS_DIR), f"Failed to install missing robot {robot_name}"
+        robot_dirs = [robot_dir for robot_dir in robot_dirs if (ROBOTS_DIR / robot_dir).is_dir()]
+        install_missing_source("robots", robot_name, robot_dirs)
+        assert robot_name in os.listdir(ROBOTS_DIR) and (ROBOTS_DIR / robot_name).is_dir(), (
+            f"Failed to install missing robot {robot_name}"
+        )
 
     return ROBOTS_DIR / robot_name
 

--- a/molmo_spaces/molmo_spaces_constants.py
+++ b/molmo_spaces/molmo_spaces_constants.py
@@ -637,7 +637,6 @@ def print_license_info(data_type, data_source, asset_or_tar_id):
 
 
 if __name__ == "__main__":
-    get_robot_path("i2rt_yam")
     resource_manager_log_level(logging.DEBUG)
     print("Setting up resources...")
     get_resource_manager(force_post_setup=True)

--- a/molmo_spaces/molmo_spaces_constants.py
+++ b/molmo_spaces/molmo_spaces_constants.py
@@ -134,6 +134,14 @@ DATA_TYPE_TO_SOURCE_TO_VERSION = dict(
 _RESOURCE_MANAGER = None
 
 
+def _select_storage():
+    return (
+        HFRemoteStorage("allenai/molmospaces", repo_prefix="mujoco", token=os.getenv("HF_TOKEN"))
+        if USE_HUGGING_FACE
+        else R2RemoteStorage("mujoco-thor-resources")
+    )
+
+
 def get_resource_manager(
     force_post_setup: bool = False, data_type_to_source_to_version: dict | None = None
 ):
@@ -178,11 +186,7 @@ def get_resource_manager(
         # resource_manager_log_level()
 
         manager = setup_resource_manager(
-            HFRemoteStorage(
-                "allenai/molmospaces", repo_prefix="mujoco", token=os.getenv("HF_TOKEN")
-            )
-            if USE_HUGGING_FACE
-            else R2RemoteStorage("mujoco-thor-resources"),
+            _select_storage(),
             symlink_dir=ASSETS_DIR,
             versions=data_type_to_source_to_version,
             cache_dir=DATA_CACHE_DIR,
@@ -585,7 +589,11 @@ def get_robot_paths() -> dict[str, Path]:
 
 def install_missing_source(data_type: str, missing_source: str, existing_sources: list[str]):
     from molmospaces_resources.manager import _lock_context, LOCAL_MANIFEST_NAME
-    from molmospaces_resources.setup_utils import _get_current_install
+    from molmospaces_resources.setup_utils import (
+        _get_current_install,
+        _RESOURCE_MANAGERS,
+        _manager_key,
+    )
 
     assert missing_source in DATA_TYPE_TO_SOURCE_TO_VERSION[data_type], (
         f"{missing_source} has no version under {data_type}"
@@ -602,11 +610,15 @@ def install_missing_source(data_type: str, missing_source: str, existing_sources
     current_install = _get_current_install(ASSETS_DIR, data_type_to_source_to_version)
     current_install[data_type][missing_source] = None
     manifest_path = ASSETS_DIR / LOCAL_MANIFEST_NAME
+    key = _manager_key(str(_select_storage()), data_type_to_source_to_version)
     with _lock_context(ASSETS_DIR, DATA_CACHE_DIR):
+        if key in _RESOURCE_MANAGERS:
+            _RESOURCE_MANAGERS.pop(key)
         with open(manifest_path, "w") as f:
             json.dump(current_install, f, indent=2)
 
     get_resource_manager(data_type_to_source_to_version=data_type_to_source_to_version)
+    assert key in _RESOURCE_MANAGERS, f"BUG: Missing expected {key} from _RESOURCE_MANAGERS"
 
 
 def get_robot_path(robot_name) -> Path:


### PR DESCRIPTION
- Added a helper function to install missing source (used to install missing robot paths).
- Tested by removing one of the robot directories from the install dir and calling get_robot_path(missing_robot_dir_name).