### PR TITLE
Fix bug in lazy robot install, speed up ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,6 @@ jobs:
           source .venv/bin/activate
           uv pip install -e .[dev,mujoco]
 
-      - name: Download assets
-        run: |
-          source .venv/bin/activate
-          python -m molmo_spaces.molmo_spaces_constants
-
       - name: Run component tests
         run: |
           source .venv/bin/activate

--- a/molmo_spaces/molmo_spaces_constants.py
+++ b/molmo_spaces/molmo_spaces_constants.py
@@ -625,7 +625,7 @@ def get_robot_path(robot_name) -> Path:
     """
     Return the path to the prepackaged MlSpaces robot file for the given robot name.
     """
-    robot_dirs = os.listdir(ROBOTS_DIR)
+    robot_dirs = os.listdir(ROBOTS_DIR) if ROBOTS_DIR.is_dir() else []
     if robot_name not in robot_dirs or not (ROBOTS_DIR / robot_name).is_dir():
         logging.info(
             f"Robot {robot_name} not found in {ROBOTS_DIR}. Attempting direct installation."


### PR DESCRIPTION
Fix a bug in the lazy robot install logic that would crash if no assets had been installed yet, so `ROBOTS_DIR` wouldn't exist.

Now that #77 is merged, we don't need to manually install all the assets before running tests in the CI, which should speed it up a bit.