### PR TITLE
Fix spurious CI failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Free disk space (Ubuntu)
-        if: runner.os == 'Linux'
+      - name: Log disk space
         run: |
           df -h /
 
@@ -44,7 +43,11 @@ jobs:
       - name: Install package
         run: |
           source .venv/bin/activate
-          uv pip install -e .[dev,mujoco]
+          uv pip install --no-cache -e .[dev,mujoco]
+
+      - name: Log disk space
+        run: |
+          df -h /
 
       - name: Run component tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install package
         run: |
           source .venv/bin/activate
-          uv pip install --no-cache -e .[dev,mujoco]
+          uv pip install -e .[dev,mujoco]
 
       - name: Log disk space
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,13 @@ jobs:
         run: |
           df -h /
 
+      - name: Free disk space (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache
+          sudo apt-get clean
+          df -h /
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -43,7 +50,7 @@ jobs:
       - name: Install package
         run: |
           source .venv/bin/activate
-          uv pip install -e .[dev,mujoco]
+          uv pip install --no-cache -e .[dev,mujoco]
 
       - name: Log disk space
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache
-          sudo apt-get clean
-          df -h /
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,7 +44,7 @@ jobs:
       - name: Install package
         run: |
           source .venv/bin/activate
-          uv pip install --no-cache -e .[dev,mujoco]
+          uv pip install -e .[dev,mujoco]
 
       - name: Run component tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Free disk space (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache
+          sudo apt-get clean
+          df -h /
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -39,7 +47,7 @@ jobs:
       - name: Install package
         run: |
           source .venv/bin/activate
-          uv pip install -e .[dev,mujoco]
+          uv pip install --no-cache -e .[dev,mujoco]
 
       - name: Run component tests
         run: |


### PR DESCRIPTION
Free up space before running CI to improve compatibility with smaller runners.

Fixes #87.