### PR TITLE
Robot improvements

### DIFF
--- a/docs/api/configs.md
+++ b/docs/api/configs.md
@@ -1,0 +1,6 @@
+# configs
+
+::: molmo_spaces.configs
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/data_generation.md
+++ b/docs/api/data_generation.md
@@ -1,0 +1,6 @@
+# data_generation
+
+::: molmo_spaces.data_generation
+    options:
+      members_order: alphabetical
+      show_submodules: true

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,12 +7,14 @@ Auto-generated documentation for the `molmo_spaces` Python package.
 | Module | Description |
 |--------|-------------|
 | [molmo_spaces](molmo_spaces.md) | Top-level package and constants |
+| [configs](configs.md) | Experiment and component configuration classes |
+| [controllers](controllers.md) | Robot controllers |
+| [data_generation](data_generation.md) | Data generation pipelines and config registry |
 | [env](env.md) | Simulation environment base classes |
-| [tasks](tasks.md) | Task definitions and reward functions |
-| [robots](robots.md) | Robot models and configurations |
-| [controllers](controllers.md) | Robot controllers (IK, impedance, etc.) |
+| [evaluation](evaluation.md) | Evaluation infrastructure and pipeline |
 | [kinematics](kinematics.md) | Kinematic utilities and solvers |
-| [renderer](renderer.md) | Rendering backends and camera utilities |
 | [policy](policy.md) | Policy interfaces and wrappers |
-| [evaluation](evaluation.md) | Evaluation metrics and protocols |
+| [renderer](renderer.md) | Rendering backends |
+| [robots](robots.md) | Robot models and abstractions |
+| [tasks](tasks.md) | Task definitions and reward functions |
 | [utils](utils.md) | Shared utilities |

--- a/docs/tutorials/add_robot/index.md
+++ b/docs/tutorials/add_robot/index.md
@@ -218,7 +218,6 @@ class XArm7RobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = XArm7Robot
     robot_namespace: str = "robot_0/"
     robot_view_factory: RobotViewFactory | None = XArm7RobotView
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]  # (xyz + quat)
     name: str = "xarm7"
     robot_xml_path: Path = Path("xarm7.xml")
     robot_dir: Path = Path("assets/ufactory_xarm7").resolve()

--- a/examples/add_robot/xarm7_config.py
+++ b/examples/add_robot/xarm7_config.py
@@ -16,7 +16,6 @@ class XArm7RobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = XArm7Robot
     robot_namespace: str = "robot_0/"
     robot_view_factory: RobotViewFactory | None = XArm7RobotView
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]  # (xyz + quat)
     name: str = "xarm7"
     robot_xml_path: Path = Path("xarm7.xml")
     robot_dir: Path = Path("assets/ufactory_xarm7").resolve()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,14 +50,16 @@ nav:
   - API Reference:
       - Overview: api/index.md
       - molmo_spaces: api/molmo_spaces.md
-      - env: api/env.md
-      - tasks: api/tasks.md
-      - robots: api/robots.md
+      - configs: api/configs.md
       - controllers: api/controllers.md
-      - kinematics: api/kinematics.md
-      - renderer: api/renderer.md
-      - policy: api/policy.md
+      - data_generation: api/data_generation.md
+      - env: api/env.md
       - evaluation: api/evaluation.md
+      - kinematics: api/kinematics.md
+      - policy: api/policy.md
+      - renderer: api/renderer.md
+      - robots: api/robots.md
+      - tasks: api/tasks.md
       - utils: api/utils.md
 
 plugins:

--- a/molmo_spaces/configs/robot_configs.py
+++ b/molmo_spaces/configs/robot_configs.py
@@ -91,7 +91,6 @@ class BaseRobotConfig(Config):
     robot_namespace: (
         str  # namespace used to differentiate between one or multiple robots and the environment
     )
-    default_world_pose: list[float]
     command_mode: dict[
         str, str
     ]  # move_group to command_mode e.g., "joint", "cartesian", "velocity"
@@ -144,7 +143,6 @@ class FrankaRobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = FrankaRobot
     robot_namespace: str = "robot_0/"
     robot_view_factory: RobotViewFactory | None = FrankaDroidRobotView
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     name: str = "franka_droid"
     robot_xml_path: Path = Path("model.xml")
     base_size: list[float] | None = [0.5, 0.5, 0.58]
@@ -180,7 +178,6 @@ class MobileFrankaRobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = MobileFrankaRobot
     robot_namespace: str = "robot_0/"
     robot_view_factory: RobotViewFactory | None = MobileFrankaDroidRobotView
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     name: str = "franka_droid"
     robot_xml_path: Path = Path("model.xml")
     base_size: list[float] = [0.5, 0.5, 0.58]
@@ -224,7 +221,6 @@ class FrankaCAPRobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = FrankaRobot
     robot_namespace: str = "robot_0/"
     robot_view_factory: RobotViewFactory | None = FrankaCAPRobotView
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     name: str = "franka_cap"
     robot_xml_path: Path = Path("model.xml")
     base_size: list[float] | None = [0.5, 0.5, 0.58]
@@ -287,7 +283,6 @@ class RBY1Config(BaseRobotConfig):
         "torso": np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     }
 
-    default_world_pose: list[float] = [0.0, 0.0, 0.0]
     use_holo_base: bool = True  # Whether to use virtual holonomic base joints or not
     command_mode: dict[str, str | None] = {
         "arm": "joint_position",  # e.g., "joint_position", "joint_velocity", "ee_position", "ee_velocity"
@@ -334,7 +329,6 @@ class FloatingRUMRobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = FloatingRUMRobot
     robot_view_factory: RobotViewFactory | None = FloatingRUMRobotView
     robot_namespace: str = "robot_0/"
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     ctrl_dt_ms: float = 50.0
     command_mode: dict = {}
     name: str = "floating_rum"
@@ -350,7 +344,6 @@ class FloatingRobotiq2f85RobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, BaseRobotConfig], Robot] = FloatingRobotiqRobot
     robot_view_factory: RobotViewFactory = FloatingRobotiq2f85RobotView
     robot_namespace: str = "robot_0/"
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     ctrl_dt_ms: float = 50.0
     command_mode: dict = {}
     action_spec: dict[str, int] = {"base": 7, "gripper": 2}  # Max lengths for action components
@@ -369,7 +362,6 @@ class I2rtYamRobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = I2rtYamRobot
     robot_view_factory: RobotViewFactory | None = I2rtYamRobotView
     robot_namespace: str = "robot_0/"
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     name: str = "i2rt_yam"
     robot_xml_path: Path = Path("yam.xml")
     # Base platform size [width, depth, height] - raises robot above ground
@@ -407,7 +399,6 @@ class BimanualYamRobotConfig(BaseRobotConfig):
     robot_factory: Callable[[MjData, Any], Robot] | None = BimanualYamRobot
     robot_view_factory: RobotViewFactory | None = BimanualYamRobotView
     robot_namespace: str = "robot_0/"
-    default_world_pose: list[float] = [0, 0, 0, 1, 0, 0, 0]
     name: str = "i2rt_yam"  # Use same directory as single-arm YAM
     robot_xml_path: Path = Path("bimanual_yam.xml")
     # Base platform size [x, y, z] - raises robot above ground

--- a/molmo_spaces/configs/robot_configs.py
+++ b/molmo_spaces/configs/robot_configs.py
@@ -202,17 +202,17 @@ class MobileFrankaRobotConfig(BaseRobotConfig):
     base_control_params: dict[str, dict[str, float]] = {
         "base_x_act": {
             "kp": 25000,
-            "kd": 1,
+            "damping_ratio": 1.0,
             "ctrlrange": 25,
         },
         "base_y_act": {
             "kp": 25000,
-            "kd": 1,
+            "damping_ratio": 1.0,
             "ctrlrange": 25,
         },
         "base_theta_act": {
             "kp": 5000,
-            "kd": 0.5,
+            "damping_ratio": 1.0,
         },
     }
 

--- a/molmo_spaces/evaluation/benchmark_schema.py
+++ b/molmo_spaces/evaluation/benchmark_schema.py
@@ -20,11 +20,10 @@ Benchmark directory structure:
 
 Key fields for robot placement:
     - robot.init_qpos: Initial joint positions per move group
-    - task.robot_base_pose: Robot base pose in world frame (NOT robot.default_world_pose)
+    - task.robot_base_pose: Robot base pose in world frame
 
 The actual robot world placement comes from task.robot_base_pose, which is set
-by the task sampler and frozen into the episode. The robot_config.default_world_pose
-field in the codebase is just a default that gets overridden.
+by the task sampler and frozen into the episode.
 
 Task horizons:
     Task horizon (max steps per episode) is an EVALUATION parameter, not a task
@@ -119,7 +118,7 @@ class BaseTaskSpec(BaseModel):
     task_type: str | None = None  # Optional human-readable type (e.g. "pick", "pick_and_place")
 
     # Robot world placement [x, y, z, qw, qx, qy, qz]
-    # This is the actual field used for robot placement (not robot.default_world_pose)
+    # This is the actual field used for robot placement
     robot_base_pose: list[float] = Field(..., min_length=7, max_length=7)
 
 

--- a/molmo_spaces/robots/mobile_franka.py
+++ b/molmo_spaces/robots/mobile_franka.py
@@ -41,8 +41,12 @@ class MobileFrankaRobot(Robot):
             or config.robot_config.command_mode["arm"] == "joint_position"
             else JointRelPosController
         )
+        base_controller_cls: type[Controller] = {
+            "holo_joint_planar_position": JointPosController,
+            "holo_joint_rel_planar_position": JointRelPosController,
+        }[config.robot_config.command_mode["base"]]
         self._controllers = {
-            "base": JointPosController(self._robot_view.get_move_group("base")),
+            "base": base_controller_cls(self._robot_view.get_move_group("base")),
             "arm": arm_controller_cls(self._robot_view.get_move_group("arm")),
             "gripper": JointPosController(self._robot_view.get_move_group("gripper")),
         }
@@ -196,11 +200,12 @@ class MobileFrankaRobot(Robot):
                 range=[-params["ctrlrange"], params["ctrlrange"]],
                 ref=pos[gear_idx],
             )
+            # use damping ratio if available, otherwise use kd (which should be negative in biasprm)
             add_slider_act(
                 act_name,
                 params["ctrlrange"],
                 params["kp"],
-                [0, -params["kp"], params["kd"]],
+                [0, -params["kp"], params.get("damping_ratio", -params.get("kd", 0.0))],
                 gear_idx,
             )
 
@@ -218,7 +223,11 @@ class MobileFrankaRobot(Robot):
             biastype=mujoco.mjtBias.mjBIAS_AFFINE,
         )
         theta_act.gainprm[0] = theta_act_params["kp"]
-        theta_act.biasprm[:3] = [0, -theta_act_params["kp"], theta_act_params["kd"]]
+        theta_act.biasprm[1] = -theta_act_params["kp"]
+        # use damping ratio if available, otherwise use kd (which should be negative in biasprm)
+        theta_act.biasprm[2] = theta_act_params.get(
+            "damping_ratio", -theta_act_params.get("kd", 0.0)
+        )
 
 
 if __name__ == "__main__":

--- a/molmo_spaces/robots/rby1.py
+++ b/molmo_spaces/robots/rby1.py
@@ -309,21 +309,11 @@ class RBY1(Robot):
         """
         return self.robot_view.get_move_group("base").pose
 
-    def reset(self, robot_joint_pos_dict=None, robot_world_pose=None) -> None:
-        """Reset the robot to its initial position or a provided set of positions and world pose."""
+    def reset(self) -> None:
+        """Reset the robot to its initial state."""
 
-        # Load default robot configuration and world pose
         init_qpos_dict = self.exp_config.robot_config.init_qpos
-        default_world_pose = self.exp_config.robot_config.default_world_pose
-        if robot_joint_pos_dict is not None:
-            for move_group_id, joint_pos in robot_joint_pos_dict.items():
-                init_qpos_dict[move_group_id] = joint_pos
-        if robot_world_pose is not None:
-            default_world_pose = robot_world_pose
-        # Set the joint positions
         self.set_joint_pos(init_qpos_dict)
-        # Set the world pose
-        self.set_world_pose(default_world_pose)
 
         # reset controllers
         for _, controller in self._controllers.items():


### PR DESCRIPTION
- Stated [here](https://github.com/google-deepmind/mujoco/blob/main/src/user/user_api.cc#L979), the sign of `biasprm` dictates whether its used as Kd or a damping ratio, so the mobile franka's base controller configuration is updated to reflect this. (functionality is preserved, but it was called "Kd" while being used as the damping ratio)
 - Remove `robot_config.default_world_pose` which was unused and redundant with other config fields.
 - Add api reference sections for config and datagen, and sort alphabetically