### PR TITLE
(feat): Add batching to datagen 

### DIFF
--- a/molmo_spaces/configs/task_sampler_configs.py
+++ b/molmo_spaces/configs/task_sampler_configs.py
@@ -16,6 +16,7 @@ class BaseMujocoTaskSamplerConfig(Config):
     house_inds: list[int] | None  # List of thor house indices to use
     scene_xml_paths: list[str] | None = None
     samples_per_house: int | None  # Number of tasks to sample per house
+    episodes_per_batch: int = 4  # Max episodes per work item; houses are split into batches of this size for parallel processing
     task_batch_size: int
     max_tasks: int | None  # Maximum number of tasks to sample
     sim_settle_timesteps: int = 500

--- a/molmo_spaces/data_generation/config/object_manipulation_datagen_configs.py
+++ b/molmo_spaces/data_generation/config/object_manipulation_datagen_configs.py
@@ -871,7 +871,7 @@ class FrankaPickBatchTestConfig(PickBaseConfig):
         task_sampler_class=PickTaskSampler,
         house_inds=[7],
         samples_per_house=12,
-        episodes_per_batch=4, # 4 is the default value - change to 1 or 10 to test different batch sizes.
+        episodes_per_batch=4,  # 4 is the default value - change to 1 or 10 to test different batch sizes.
     )
     filter_for_successful_trajectories: bool = True
     output_dir: Path = ASSETS_DIR / "experiment_output" / "datagen" / "pick_batch_test"

--- a/molmo_spaces/data_generation/config/object_manipulation_datagen_configs.py
+++ b/molmo_spaces/data_generation/config/object_manipulation_datagen_configs.py
@@ -854,3 +854,29 @@ class RUMPickAndPlaceMultiDataGenConfig(PickAndPlaceDataGenConfig):
     @property
     def tag(self) -> str:
         return "pnpmulti_bench"
+
+
+@register_config("FrankaPickBatchTestConfig")
+class FrankaPickBatchTestConfig(PickBaseConfig):
+    """Minimal config to test local batch-based work distribution.
+
+    Single house, 12 episodes split into 3 batches of 4, processed by 2 workers.
+    Output: house_7/trajectories_batch_{1,2,3}_of_3.h5
+    """
+
+    num_workers: int = 2
+    robot_config: BaseRobotConfig = FrankaRobotConfig()
+    camera_config: FrankaDroidCameraSystem = FrankaDroidCameraSystem()
+    task_sampler_config: PickTaskSamplerConfig = PickTaskSamplerConfig(
+        task_sampler_class=PickTaskSampler,
+        house_inds=[7],
+        samples_per_house=12,
+        episodes_per_batch=4, # 4 is the default value - change to 1 or 10 to test different batch sizes.
+    )
+    filter_for_successful_trajectories: bool = True
+    output_dir: Path = ASSETS_DIR / "experiment_output" / "datagen" / "pick_batch_test"
+    log_level: str = "debug"
+
+    @property
+    def tag(self) -> str:
+        return "franka_pick_batch_test"

--- a/molmo_spaces/data_generation/pipeline.py
+++ b/molmo_spaces/data_generation/pipeline.py
@@ -335,8 +335,7 @@ def cleanup_context():
 def house_processing_worker(
     worker_id: int,
     exp_config: MlSpacesExpConfig,
-    house_indices: list[int],
-    samples_per_house: int,
+    work_items: list[tuple[int, int, int, int]],
     shutdown_event,
     counter_lock,
     house_counter,
@@ -352,23 +351,23 @@ def house_processing_worker(
     runner_class=None,
 ):
     """
-    Standalone worker function that processes houses sequentially from a shared counter.
+    Standalone worker function that processes work items sequentially from a shared counter.
 
+    Each work item is a (house_id, batch_samples, batch_num, total_batches) tuple.
     This function can be run in either a thread or a process. It continually fetches
-    the next house index from a shared counter and processes it.
+    the next work item from a shared counter and processes it.
 
     Args:
         worker_id: Unique ID for this worker
         exp_config: Experiment configuration
-        house_indices: List of all house indices to process
-        samples_per_house: Number of episodes per house
+        work_items: List of (house_id, batch_samples, batch_num, total_batches) tuples
         shutdown_event: Event to signal shutdown
         counter_lock: Lock for thread-safe counter access
-        house_counter: Shared counter for next house to process
+        house_counter: Shared counter for next work item to process
         success_count: Shared counter for successful episodes
         total_count: Shared counter for total episodes
-        completed_houses: Shared counter for completed houses
-        skipped_houses: Shared counter for skipped houses
+        completed_houses: Shared counter for completed work items
+        skipped_houses: Shared counter for skipped work items
         max_allowed_sequential_task_sampler_failures: Max consecutive task sampling failures
         max_allowed_sequential_rollout_failures: Max consecutive rollout failures
         max_allowed_sequential_irrecoverable_failures: Max consecutive irrecoverable failures
@@ -405,26 +404,28 @@ def house_processing_worker(
                     )
                     break
 
-                # Get next house to process atomically
+                # Get next work item to process atomically
                 with counter_lock:
-                    if house_counter.value >= len(house_indices):
-                        break  # No more houses to process
-                    house_idx = house_counter.value
-                    current_house_id = house_indices[house_idx]
+                    if house_counter.value >= len(work_items):
+                        break  # No more work items to process
+                    item_idx = house_counter.value
                     house_counter.value += 1
+                current_house_id, batch_samples, batch_num, total_batches = work_items[item_idx]
 
                 worker_logger.info(
-                    f"Worker {worker_id} starting house {current_house_id} (index {house_idx}/{len(house_indices)})"
+                    f"Worker {worker_id} starting house {current_house_id} "
+                    f"batch {batch_num}/{total_batches} ({batch_samples} episodes) "
+                    f"(item {item_idx}/{len(work_items)})"
                 )
 
-                # Process this house
+                # Process this work item
                 house_success_count, house_total_count, irrecoverable = (
                     runner_class.process_single_house(
                         worker_id,
                         worker_logger,
                         current_house_id,
                         exp_config,
-                        samples_per_house,
+                        batch_samples,
                         shutdown_event,
                         task_sampler,
                         preloaded_policy,
@@ -432,6 +433,8 @@ def house_processing_worker(
                         max_allowed_sequential_rollout_failures,
                         filter_for_successful_trajectories=filter_for_successful_trajectories,
                         runner_class=runner_class,
+                        batch_num=batch_num,
+                        total_batches=total_batches,
                         datagen_profiler=datagen_profiler,
                     )
                 )
@@ -461,7 +464,7 @@ def house_processing_worker(
                     # Reset counter on success
                     num_sequential_irrecoverable_failures = 0
 
-            worker_logger.info(f"Worker {worker_id} completed processing assigned houses")
+            worker_logger.info(f"Worker {worker_id} completed processing assigned work items")
         finally:
             # Log final profiling summary for this worker
             if datagen_profiler is not None:
@@ -535,6 +538,17 @@ class ParallelRolloutRunner:
 
         self.total_houses = len(self.house_indices)
 
+        # Build (house_id, batch_samples, batch_num, total_batches) work items
+        episodes_per_batch = exp_config.task_sampler_config.episodes_per_batch
+        self.work_items: list[tuple[int, int, int, int]] = []
+        for house_id in self.house_indices:
+            total_batches = max(1, round(self.samples_per_house / episodes_per_batch))
+            base = self.samples_per_house // total_batches
+            extra = self.samples_per_house % total_batches
+            for b in range(total_batches):
+                batch_samples = base + (1 if b < extra else 0)
+                self.work_items.append((house_id, batch_samples, b + 1, total_batches))
+
         # Failure tracking limits
         self.max_allowed_sequential_task_sampler_failures = (
             exp_config.task_sampler_config.max_allowed_sequential_task_sampler_failures
@@ -585,7 +599,8 @@ class ParallelRolloutRunner:
                         "num_workers": exp_config.num_workers,
                         "total_houses": self.total_houses,
                         "samples_per_house": self.samples_per_house,
-                        "total_expected_episodes": self.total_houses * self.samples_per_house,
+                        "total_work_items": len(self.work_items),
+                        "total_expected_episodes": sum(wi[1] for wi in self.work_items),
                         "output_dir": str(exp_config.output_dir),
                         "filter_for_successful_trajectories": exp_config.filter_for_successful_trajectories,
                     },
@@ -1197,10 +1212,10 @@ class ParallelRolloutRunner:
         Returns:
             tuple: (success_count, total_count)
         """
-        total_expected_episodes = self.total_houses * self.samples_per_house
+        total_expected_episodes = sum(wi[1] for wi in self.work_items)
         self.logger.info(
-            f"Starting house-by-house rollout of {self.total_houses} houses "
-            f"with {self.samples_per_house} episodes each ({total_expected_episodes} total episodes) "
+            f"Starting rollout of {self.total_houses} houses "
+            f"split into {len(self.work_items)} work items ({total_expected_episodes} total episodes) "
             f"using {self.config.num_workers} worker processes"
         )
 
@@ -1221,8 +1236,7 @@ class ParallelRolloutRunner:
                     args=(
                         worker_id,
                         self.config,
-                        self.house_indices,
-                        self.samples_per_house,
+                        self.work_items,
                         self.shutdown_event,
                         self.counter_lock,
                         self.house_counter,
@@ -1259,9 +1273,10 @@ class ParallelRolloutRunner:
                         active = sum(1 for p in processes if p.is_alive())
 
                         # Calculate metrics
+                        total_work_items = len(self.work_items)
                         success_rate = success / total if total > 0 else 0.0
                         episodes_per_second = total / elapsed_time if elapsed_time > 0 else 0.0
-                        completion_percentage = (completed + skipped) / self.total_houses * 100
+                        completion_percentage = (completed + skipped) / total_work_items * 100
 
                         # Log to WandB
                         wandb.log(
@@ -1279,7 +1294,7 @@ class ParallelRolloutRunner:
                             }
                         )
                         self.logger.info(
-                            f"Progress: {completed}/{self.total_houses} houses completed "
+                            f"Progress: {completed}/{total_work_items} work items completed "
                             f"({completion_percentage:.1f}%), {success}/{total} successful episodes "
                             f"({success_rate * 100:.1f}%), {active} workers active"
                         )
@@ -1301,8 +1316,7 @@ class ParallelRolloutRunner:
             house_processing_worker(
                 worker_id=0,
                 exp_config=self.config,
-                house_indices=self.house_indices,
-                samples_per_house=self.samples_per_house,
+                work_items=self.work_items,
                 shutdown_event=self.shutdown_event,
                 counter_lock=self.counter_lock,
                 house_counter=self.house_counter,
@@ -1315,9 +1329,7 @@ class ParallelRolloutRunner:
                 max_allowed_sequential_irrecoverable_failures=self.max_allowed_sequential_irrecoverable_failures,
                 preloaded_policy=preloaded_policy,
                 filter_for_successful_trajectories=self.config.filter_for_successful_trajectories,
-                runner_class=type(
-                    self
-                ),  # Pass the runner class to enable customization via subclassing
+                runner_class=type(self),
             )
 
         # Extract final values from shared multiprocessing state
@@ -1328,7 +1340,7 @@ class ParallelRolloutRunner:
 
         success_rate = success_count_val / total_count_val if total_count_val > 0 else 0.0
         self.logger.info(
-            f"Completed {completed_houses_val} houses, skipped {skipped_houses_val} houses"
+            f"Completed {completed_houses_val} work items, skipped {skipped_houses_val} work items"
         )
         self.logger.info(f"Success count: {success_count_val}, Total count: {total_count_val}")
         self.logger.info(f"Success rate: {success_rate * 100:.2f}%")


### PR DESCRIPTION
Default size 4 episodes, all files now have structure per house example trajectories_batch_2_of_4.h5. Enables easy multi-worker generation of many episodes against a single house.