### PR TITLE
Refactor policy instantiation

### DIFF
--- a/mlspaces_tests/data_generation/config.py
+++ b/mlspaces_tests/data_generation/config.py
@@ -54,6 +54,7 @@ class FrankaPickDroidTestConfig(FrankaPickDroidDataGenConfig):
         super().model_post_init(__context)
 
         self.policy_config.policy_cls = PickPlannerPolicy
+        self.policy_config.policy_factory = PickPlannerPolicy
 
         # Override house to use for testing (use house 8, the default)
         self.task_sampler_config.house_inds = [8]
@@ -88,6 +89,7 @@ class FrankaPickRandomizedTestConfig(FrankaPickRandomizedDataGenConfig):
         super().model_post_init(__context)
 
         self.policy_config.policy_cls = PickPlannerPolicy
+        self.policy_config.policy_factory = PickPlannerPolicy
 
         # Override house to use for testing (use house 8, the default)
         self.task_sampler_config.house_inds = [8]

--- a/mlspaces_tests/data_generation/generate_test_data_pick.py
+++ b/mlspaces_tests/data_generation/generate_test_data_pick.py
@@ -66,8 +66,8 @@ def generate_test_data_for_config(config_orig, config_name: str):
     # Run policy - follow pipeline.py pattern (line 295)
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/generate_test_data_pick_and_place.py
+++ b/mlspaces_tests/data_generation/generate_test_data_pick_and_place.py
@@ -70,8 +70,8 @@ def generate_test_data_for_config(config, config_name: str):
     # Run policy - follow pipeline.py pattern (line 295)
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/generate_test_data_rum_open_close.py
+++ b/mlspaces_tests/data_generation/generate_test_data_rum_open_close.py
@@ -65,8 +65,8 @@ def generate_test_data_for_rum_open():
     # Run policy - follow pipeline.py pattern
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations
@@ -138,8 +138,8 @@ def generate_test_data_for_rum_close():
     # Run policy - follow pipeline.py pattern
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/generate_test_data_rum_pick.py
+++ b/mlspaces_tests/data_generation/generate_test_data_rum_pick.py
@@ -66,8 +66,8 @@ def generate_test_data_for_rum():
     # Run policy - follow pipeline.py pattern (line 295)
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation/test_franka_pick.py
+++ b/mlspaces_tests/data_generation/test_franka_pick.py
@@ -107,8 +107,8 @@ def droid_policy_results(droid_config, droid_task):
 
     # Instantiate policy with config and task
     policy_config = droid_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(droid_config, droid_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(droid_config, droid_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations
@@ -134,8 +134,8 @@ def randomized_policy_results(randomized_config, randomized_task):
 
     # Instantiate policy with config and task
     policy_config = randomized_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(randomized_config, randomized_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(randomized_config, randomized_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations

--- a/mlspaces_tests/data_generation/test_franka_pick_and_place.py
+++ b/mlspaces_tests/data_generation/test_franka_pick_and_place.py
@@ -89,8 +89,8 @@ def droid_policy_results(droid_config, droid_task):
 
     # Instantiate policy with config and task
     policy_config = droid_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(droid_config, droid_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(droid_config, droid_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations
@@ -144,8 +144,8 @@ def gopro_policy_results(gopro_config, gopro_task):
 
     # Instantiate policy with config and task
     policy_config = gopro_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(gopro_config, gopro_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(gopro_config, gopro_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations

--- a/mlspaces_tests/data_generation/test_rum_open_close.py
+++ b/mlspaces_tests/data_generation/test_rum_open_close.py
@@ -78,8 +78,8 @@ def rum_open_policy_results(rum_open_config, rum_open_task):
 
     # Instantiate policy with config and task
     policy_config = rum_open_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(rum_open_config, rum_open_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(rum_open_config, rum_open_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations
@@ -138,8 +138,8 @@ def rum_close_policy_results(rum_close_config, rum_close_task):
 
     # Instantiate policy with config and task
     policy_config = rum_close_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(rum_close_config, rum_close_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(rum_close_config, rum_close_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations

--- a/mlspaces_tests/data_generation/test_rum_pick.py
+++ b/mlspaces_tests/data_generation/test_rum_pick.py
@@ -73,8 +73,8 @@ def rum_policy_results(rum_config, rum_task):
 
     # Instantiate policy with config and task
     policy_config = rum_config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(rum_config, rum_task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(rum_config, rum_task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations

--- a/mlspaces_tests/data_generation_curobo/generate_test_data_rby1_door_opening.py
+++ b/mlspaces_tests/data_generation_curobo/generate_test_data_rby1_door_opening.py
@@ -77,8 +77,8 @@ def generate_test_data_for_rby1():
     # Run policy and capture observations after steps
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation_curobo/generate_test_data_rby1_pnp.py
+++ b/mlspaces_tests/data_generation_curobo/generate_test_data_rby1_pnp.py
@@ -64,8 +64,8 @@ def generate_test_data_for_rby1():
     # Run policy and capture observations after steps
     print("\n=== Running policy and capturing observations after steps ===")
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps using shared utility and capture observations

--- a/mlspaces_tests/data_generation_curobo/test_rby1_door_opening.py
+++ b/mlspaces_tests/data_generation_curobo/test_rby1_door_opening.py
@@ -91,8 +91,8 @@ def policy_results(config, task):
 
     # Instantiate policy with config and task
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations

--- a/mlspaces_tests/data_generation_curobo/test_rby1_pnp.py
+++ b/mlspaces_tests/data_generation_curobo/test_rby1_pnp.py
@@ -90,8 +90,8 @@ def policy_results(config, task):
 
     # Instantiate policy with config and task
     policy_config = config.policy_config
-    policy_cls = policy_config.policy_cls
-    policy = policy_cls(config, task)
+    policy_factory = policy_config.policy_factory
+    policy = policy_factory(config, task)
     policy.reset()
 
     # Run policy for 10 steps and get both qpos and observations

--- a/mlspaces_tests/door_opening_test_config.py
+++ b/mlspaces_tests/door_opening_test_config.py
@@ -27,8 +27,9 @@ class DoorOpeningTestConfig(DoorOpeningSingleSceneConfig):
         policy_cls = DummyPolicy
 
         policy_config = BasePolicyConfig(
-            policy_dt_ms=self.policy_dt_ms,
-            type="dummy",
+            policy_cls=DummyPolicy,
+            policy_factory=lambda config, task: DummyPolicy(config),
+            policy_type="dummy",
         )
 
         return (policy_cls, policy_config)

--- a/mlspaces_tests/door_opening_test_config.py
+++ b/mlspaces_tests/door_opening_test_config.py
@@ -2,6 +2,7 @@ from molmo_spaces.configs.policy_configs import BasePolicyConfig
 from molmo_spaces.data_generation.config.door_opening_configs import DoorOpeningSingleSceneConfig
 from molmo_spaces.data_generation.config_registry import register_config
 from molmo_spaces.policy.dummy_policy import DummyPolicy
+from molmo_spaces.utils.function_utils import make_lenient
 
 
 @register_config("DoorOpeningTestConfig")
@@ -28,7 +29,7 @@ class DoorOpeningTestConfig(DoorOpeningSingleSceneConfig):
 
         policy_config = BasePolicyConfig(
             policy_cls=DummyPolicy,
-            policy_factory=lambda config, task: DummyPolicy(config),
+            policy_factory=make_lenient(DummyPolicy),
             policy_type="dummy",
         )
 

--- a/molmo_spaces/configs/dummy_config.py
+++ b/molmo_spaces/configs/dummy_config.py
@@ -1,6 +1,7 @@
 from molmo_spaces.configs.policy_configs import BasePolicyConfig
 from molmo_spaces.policy.base_policy import PolicyFactory
 from molmo_spaces.policy.dummy_policy import DummyPolicy
+from molmo_spaces.utils.function_utils import make_lenient
 
 
 class DummyPolicyConfig(BasePolicyConfig):
@@ -13,5 +14,5 @@ class DummyPolicyConfig(BasePolicyConfig):
     def model_post_init(self, __context) -> None:
         super().model_post_init(__context)
         if self.policy_cls is None:
-            object.__setattr__(self, "policy_cls", DummyPolicy)
-            object.__setattr__(self, "policy_factory", lambda config, task: DummyPolicy(config))
+            self.policy_cls = DummyPolicy
+            self.policy_factory = make_lenient(DummyPolicy)

--- a/molmo_spaces/configs/dummy_config.py
+++ b/molmo_spaces/configs/dummy_config.py
@@ -1,4 +1,5 @@
 from molmo_spaces.configs.policy_configs import BasePolicyConfig
+from molmo_spaces.policy.base_policy import PolicyFactory
 from molmo_spaces.policy.dummy_policy import DummyPolicy
 
 
@@ -7,8 +8,10 @@ class DummyPolicyConfig(BasePolicyConfig):
 
     policy_type: str = "dummy"
     policy_cls: type = None  # type: ignore
+    policy_factory: PolicyFactory | None = None
 
     def model_post_init(self, __context) -> None:
         super().model_post_init(__context)
         if self.policy_cls is None:
             object.__setattr__(self, "policy_cls", DummyPolicy)
+            object.__setattr__(self, "policy_factory", lambda config, task: DummyPolicy(config))

--- a/molmo_spaces/configs/policy_configs.py
+++ b/molmo_spaces/configs/policy_configs.py
@@ -9,6 +9,7 @@ import numpy as np
 from molmo_spaces.configs.abstract_config import Config
 from molmo_spaces.planner.astar_planner import AStarPlannerConfig
 from molmo_spaces.policy.base_policy import BasePolicy, PolicyFactory
+from molmo_spaces.utils.function_utils import make_lenient
 
 # Import CuroboPlannerConfig if available (requires GPU), otherwise create a stub
 try:
@@ -434,7 +435,7 @@ class DummyPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.dummy_policy import DummyPolicy
 
             self.policy_cls = DummyPolicy
-            self.policy_factory = lambda config, task: DummyPolicy(config)
+            self.policy_factory = make_lenient(DummyPolicy)
 
 
 class BrownianMotionPolicyConfig(BasePolicyConfig):
@@ -451,4 +452,4 @@ class BrownianMotionPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.dummy_policy import BrownianMotionPolicy
 
             self.policy_cls = BrownianMotionPolicy
-            self.policy_factory = lambda config, task: BrownianMotionPolicy(config)
+            self.policy_factory = make_lenient(BrownianMotionPolicy)

--- a/molmo_spaces/configs/policy_configs.py
+++ b/molmo_spaces/configs/policy_configs.py
@@ -30,7 +30,9 @@ class BasePolicyConfig(Config):
     """Base configuration for policies."""
 
     policy_cls: type[BasePolicy]
-    policy_factory: PolicyFactory  # factory function to create the policy instance, can be same as policy_cls
+    policy_factory: (
+        PolicyFactory  # factory function to create the policy instance, can be same as policy_cls
+    )
     policy_type: str  # Type of the policy, e.g., "planner", "teleop", "learned", etc.
 
 

--- a/molmo_spaces/configs/policy_configs.py
+++ b/molmo_spaces/configs/policy_configs.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from molmo_spaces.configs.abstract_config import Config
 from molmo_spaces.planner.astar_planner import AStarPlannerConfig
-from molmo_spaces.policy.base_policy import BasePolicy
+from molmo_spaces.policy.base_policy import BasePolicy, PolicyFactory
 
 # Import CuroboPlannerConfig if available (requires GPU), otherwise create a stub
 try:
@@ -29,9 +29,8 @@ except (ImportError, RuntimeError):
 class BasePolicyConfig(Config):
     """Base configuration for policies."""
 
-    policy_cls: type[
-        BasePolicy
-    ]  # unless pre-instantiated before eval/datagen, should take (config, task) in constructor
+    policy_cls: type[BasePolicy]
+    policy_factory: PolicyFactory  # factory function to create the policy instance, can be same as policy_cls
     policy_type: str  # Type of the policy, e.g., "planner", "teleop", "learned", etc.
 
 
@@ -39,6 +38,7 @@ class ObjectManipulationPlannerPolicyConfig(BasePolicyConfig):
     """Configuration for Franka pick planner policy."""
 
     policy_cls: type = None  # Will be set by importing module to avoid circular imports
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "planner"
 
     # Pick-and-place pose offsets
@@ -128,6 +128,7 @@ class OpenClosePlannerPolicyConfig(ObjectManipulationPlannerPolicyConfig):
             )
 
             self.policy_cls = OpenClosePlannerPolicy
+            self.policy_factory = OpenClosePlannerPolicy
 
 
 class PickPlannerPolicyConfig(ObjectManipulationPlannerPolicyConfig):
@@ -143,6 +144,7 @@ class PickPlannerPolicyConfig(ObjectManipulationPlannerPolicyConfig):
             )
 
             self.policy_cls = PickPlannerPolicy
+            self.policy_factory = PickPlannerPolicy
 
 
 class PickAndPlacePlannerPolicyConfig(ObjectManipulationPlannerPolicyConfig):
@@ -158,6 +160,7 @@ class PickAndPlacePlannerPolicyConfig(ObjectManipulationPlannerPolicyConfig):
             )
 
             self.policy_cls = PickAndPlacePlannerPolicy
+            self.policy_factory = PickAndPlacePlannerPolicy
 
 
 class CuroboOpenClosePlannerPolicyConfig(OpenClosePlannerPolicyConfig):
@@ -261,6 +264,7 @@ class PickAndPlaceNextToPlannerPolicyConfig(PickAndPlacePlannerPolicyConfig):
         )
 
         self.policy_cls = PickAndPlaceNextToPlannerPolicy
+        self.policy_factory = PickAndPlaceNextToPlannerPolicy
 
 
 class PickAndPlaceColorPlannerPolicyConfig(PickAndPlacePlannerPolicyConfig):
@@ -273,12 +277,14 @@ class PickAndPlaceColorPlannerPolicyConfig(PickAndPlacePlannerPolicyConfig):
         )
 
         self.policy_cls = PickAndPlaceColorPlannerPolicy
+        self.policy_factory = PickAndPlaceColorPlannerPolicy
 
 
 class DoorOpeningPolicyConfig(BasePolicyConfig):
     """Configuration for RBY1 door opening planner policy."""
 
     policy_cls: type = None  # Will be set by importing module to avoid circular imports
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "planner"
 
     # RBY1-specific policy parameters
@@ -353,6 +359,7 @@ class NavToObjPlannerPolicyConfig(BasePolicyConfig):
     """Base configuration for navigation to object planner policies."""
 
     policy_cls: type = None  # Will be set by importing module to avoid circular imports
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "planner"
 
     # Recovery motion parameters
@@ -409,6 +416,7 @@ class AStarNavToObjPolicyConfig(NavToObjPlannerPolicyConfig):
             )
 
             self.policy_cls = AStarSmoothPlannerPolicy
+            self.policy_factory = AStarSmoothPlannerPolicy
 
 
 class DummyPolicyConfig(BasePolicyConfig):
@@ -416,19 +424,22 @@ class DummyPolicyConfig(BasePolicyConfig):
 
     policy_type: str = "dummy"
     policy_cls: type = None  # Set in model_post_init
+    policy_factory: PolicyFactory | None = None
 
     def model_post_init(self, __context) -> None:
         super().model_post_init(__context)
         if self.policy_cls is None:
             from molmo_spaces.policy.dummy_policy import DummyPolicy
 
-            object.__setattr__(self, "policy_cls", DummyPolicy)
+            self.policy_cls = DummyPolicy
+            self.policy_factory = lambda config, task: DummyPolicy(config)
 
 
 class BrownianMotionPolicyConfig(BasePolicyConfig):
     """Policy that applies Gaussian noise increments over noop control, resulting in Brownian motion."""
 
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "dummy"
     std: float = 0.1
 
@@ -438,3 +449,4 @@ class BrownianMotionPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.dummy_policy import BrownianMotionPolicy
 
             self.policy_cls = BrownianMotionPolicy
+            self.policy_factory = lambda config, task: BrownianMotionPolicy(config)

--- a/molmo_spaces/configs/policy_configs_baselines.py
+++ b/molmo_spaces/configs/policy_configs_baselines.py
@@ -1,5 +1,6 @@
 from molmo_spaces.configs.policy_configs import BasePolicyConfig
 from molmo_spaces.policy.base_policy import PolicyFactory
+from molmo_spaces.utils.function_utils import make_lenient
 
 
 class PiPolicyConfig(BasePolicyConfig):
@@ -22,7 +23,7 @@ class PiPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.learned_policy.pi_policy import PI_Policy
 
             self.policy_cls = PI_Policy
-            self.policy_factory = lambda config, task: PI_Policy(config)
+            self.policy_factory = make_lenient(PI_Policy)
 
 
 class DreamZeroPolicyConfig(BasePolicyConfig):
@@ -43,7 +44,7 @@ class DreamZeroPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.learned_policy.dreamzero_policy import DreamZero_Policy
 
             self.policy_cls = DreamZero_Policy
-            self.policy_factory = lambda config, task: DreamZero_Policy(config)
+            self.policy_factory = make_lenient(DreamZero_Policy)
 
 
 class CAPPolicyConfig(BasePolicyConfig):
@@ -63,7 +64,7 @@ class CAPPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.learned_policy.cap_policy import CAP_Policy
 
             self.policy_cls = CAP_Policy
-            self.policy_factory = lambda config, task: CAP_Policy(config)
+            self.policy_factory = make_lenient(CAP_Policy)
 
 
 class TeleopPolicyConfig(BasePolicyConfig):
@@ -87,17 +88,17 @@ class TeleopPolicyConfig(BasePolicyConfig):
                 from molmo_spaces.policy.learned_policy.keyboard_policy import Keyboard_Policy
 
                 self.policy_cls = Keyboard_Policy
-                self.policy_factory = lambda config, task: Keyboard_Policy(config)
+                self.policy_factory = make_lenient(Keyboard_Policy)
             elif self.device == "spacemouse":
                 from molmo_spaces.policy.learned_policy.spacemouse_policy import SpaceMouse_Policy
 
                 self.policy_cls = SpaceMouse_Policy
-                self.policy_factory = lambda config, task: SpaceMouse_Policy(config)
+                self.policy_factory = make_lenient(SpaceMouse_Policy)
             elif self.device == "phone":
                 from molmo_spaces.policy.learned_policy.phone_policy import Phone_Policy
 
                 self.policy_cls = Phone_Policy
-                self.policy_factory = lambda config, task: Phone_Policy(config)
+                self.policy_factory = make_lenient(Phone_Policy)
 
 
 class BimanualYamPiPolicyConfig(BasePolicyConfig):
@@ -134,4 +135,4 @@ class BimanualYamPiPolicyConfig(BasePolicyConfig):
             )
 
             self.policy_cls = BimanualYamPiPolicy
-            self.policy_factory = lambda config, task: BimanualYamPiPolicy(config)
+            self.policy_factory = make_lenient(BimanualYamPiPolicy)

--- a/molmo_spaces/configs/policy_configs_baselines.py
+++ b/molmo_spaces/configs/policy_configs_baselines.py
@@ -1,4 +1,5 @@
 from molmo_spaces.configs.policy_configs import BasePolicyConfig
+from molmo_spaces.policy.base_policy import PolicyFactory
 
 
 class PiPolicyConfig(BasePolicyConfig):
@@ -11,6 +12,7 @@ class PiPolicyConfig(BasePolicyConfig):
     chunk_size: int = 8
 
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "learned"
 
     def model_post_init(self, __context) -> None:
@@ -20,6 +22,7 @@ class PiPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.learned_policy.pi_policy import PI_Policy
 
             self.policy_cls = PI_Policy
+            self.policy_factory = lambda config, task: PI_Policy(config)
 
 
 class DreamZeroPolicyConfig(BasePolicyConfig):
@@ -30,6 +33,7 @@ class DreamZeroPolicyConfig(BasePolicyConfig):
     chunk_size: int = 24
 
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "learned"
 
     def model_post_init(self, __context) -> None:
@@ -39,6 +43,7 @@ class DreamZeroPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.learned_policy.dreamzero_policy import DreamZero_Policy
 
             self.policy_cls = DreamZero_Policy
+            self.policy_factory = lambda config, task: DreamZero_Policy(config)
 
 
 class CAPPolicyConfig(BasePolicyConfig):
@@ -46,6 +51,7 @@ class CAPPolicyConfig(BasePolicyConfig):
     grasping_type: str = "binary"
     grasping_threshold: float = 0.7
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "learned"
     use_vlm: bool = False  # required for non-pick tasks
     exo_vlm: bool = True  # not used if use_vlm is False
@@ -57,11 +63,13 @@ class CAPPolicyConfig(BasePolicyConfig):
             from molmo_spaces.policy.learned_policy.cap_policy import CAP_Policy
 
             self.policy_cls = CAP_Policy
+            self.policy_factory = lambda config, task: CAP_Policy(config)
 
 
 class TeleopPolicyConfig(BasePolicyConfig):
     device: str = "keyboard"  # "spacemouse", "keyboard", "phone"
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "teleop"
     # keyboard params
     step_size: float = 0.005
@@ -79,14 +87,17 @@ class TeleopPolicyConfig(BasePolicyConfig):
                 from molmo_spaces.policy.learned_policy.keyboard_policy import Keyboard_Policy
 
                 self.policy_cls = Keyboard_Policy
+                self.policy_factory = lambda config, task: Keyboard_Policy(config)
             elif self.device == "spacemouse":
                 from molmo_spaces.policy.learned_policy.spacemouse_policy import SpaceMouse_Policy
 
                 self.policy_cls = SpaceMouse_Policy
+                self.policy_factory = lambda config, task: SpaceMouse_Policy(config)
             elif self.device == "phone":
                 from molmo_spaces.policy.learned_policy.phone_policy import Phone_Policy
 
                 self.policy_cls = Phone_Policy
+                self.policy_factory = lambda config, task: Phone_Policy(config)
 
 
 class BimanualYamPiPolicyConfig(BasePolicyConfig):
@@ -111,6 +122,7 @@ class BimanualYamPiPolicyConfig(BasePolicyConfig):
     )
 
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
     policy_type: str = "learned"
 
     def model_post_init(self, __context) -> None:
@@ -122,3 +134,4 @@ class BimanualYamPiPolicyConfig(BasePolicyConfig):
             )
 
             self.policy_cls = BimanualYamPiPolicy
+            self.policy_factory = lambda config, task: BimanualYamPiPolicy(config)

--- a/molmo_spaces/data_generation/config/door_opening_configs.py
+++ b/molmo_spaces/data_generation/config/door_opening_configs.py
@@ -108,6 +108,7 @@ class DoorOpeningDataGenConfig(MlSpacesExpConfig):
 
         return DoorOpeningPolicyConfig(
             policy_cls=DoorOpeningPlannerPolicy,
+            policy_factory=DoorOpeningPlannerPolicy,
             left_curobo_planner_config=left_curobo_planner_config,
             right_curobo_planner_config=right_curobo_planner_config,
         )

--- a/molmo_spaces/data_generation/config/object_manipulation_datagen_configs.py
+++ b/molmo_spaces/data_generation/config/object_manipulation_datagen_configs.py
@@ -302,6 +302,7 @@ class RBY1OpenDataGenConfig(OpeningBaseConfig):
         )
         return CuroboOpenClosePlannerPolicyConfig(
             policy_cls=CuroboOpenClosePlannerPolicy,
+            policy_factory=CuroboOpenClosePlannerPolicy,
             left_curobo_planner_config=left_curobo_planner_config,
             right_curobo_planner_config=right_curobo_planner_config,
         )
@@ -357,6 +358,7 @@ class RBY1PickAndPlaceDataGenConfig(PickAndPlaceDataGenConfig):
         )
         return CuroboPickAndPlacePlannerPolicyConfig(
             policy_cls=CuroboPickAndPlacePlannerPolicy,
+            policy_factory=CuroboPickAndPlacePlannerPolicy,
             left_curobo_planner_config=left_curobo_planner_config,
             right_curobo_planner_config=right_curobo_planner_config,
             enable_collision_avoidance=True,
@@ -433,6 +435,7 @@ class RBY1PickDataGenConfig(PickBaseConfig):
         )
         return CuroboPickAndPlacePlannerPolicyConfig(
             policy_cls=CuroboPickAndPlacePlannerPolicy,
+            policy_factory=CuroboPickAndPlacePlannerPolicy,
             left_curobo_planner_config=left_curobo_planner_config,
             right_curobo_planner_config=right_curobo_planner_config,
             enable_collision_avoidance=True,

--- a/molmo_spaces/data_generation/pipeline.py
+++ b/molmo_spaces/data_generation/pipeline.py
@@ -129,7 +129,7 @@ def setup_policy(
     if preloaded_policy is not None:
         policy = preloaded_policy
     else:
-        policy = exp_config.policy_config.policy_cls(exp_config, task)
+        policy = exp_config.policy_config.policy_factory(exp_config, task)
 
     task.register_policy(policy)
 

--- a/molmo_spaces/evaluation/README.md
+++ b/molmo_spaces/evaluation/README.md
@@ -127,8 +127,8 @@ Extend `InferencePolicy`. Must implement `prepare_model`, `reset`, and `get_acti
 from molmo_spaces.policy.base_policy import InferencePolicy
 
 class MyPolicy(InferencePolicy):
-    def __init__(self, config, task_type):
-        super().__init__(config, task_type)
+    def __init__(self, config, task):
+        super().__init__(config, task)
         self.camera_names = config.policy_config.camera_names
         self.action_spec = config.policy_config.action_spec
         self.prepare_model()
@@ -160,16 +160,19 @@ Extend `BasePolicyConfig`. Define your model's interface.
 ```python
 # my_repo/configs.py
 from molmo_spaces.configs.policy_configs import BasePolicyConfig
+from molmo_spaces.policy.base_policy import PolicyFactory
 
 class MyPolicyConfig(BasePolicyConfig):
     policy_type: str = "learned"
     action_type: str = "joint_pos_rel"
     policy_cls: type = None
+    policy_factory: PolicyFactory | None = None
 
     def model_post_init(self, __context):
         if self.policy_cls is None:
             from my_repo.policy import MyPolicy
-            object.__setattr__(self, "policy_cls", MyPolicy)
+            self.policy_cls = MyPolicy
+            self.policy_factory = MyPolicy
 
     checkpoint_path: str
     camera_names: list[str] = ["exo_camera_1", "wrist_camera"]

--- a/molmo_spaces/evaluation/configs/evaluation_configs.py
+++ b/molmo_spaces/evaluation/configs/evaluation_configs.py
@@ -238,6 +238,7 @@ class DummyPickPlaceEvalConfig(FrankaPickAndPlaceDataGenConfig):
 
     def _init_policy_config(self) -> DummyPolicyConfig:
         self.policy_config.policy_cls = DummyPolicy
+        self.policy_config.policy_factory = lambda config, task: DummyPolicy(config)
         return self.policy_config
 
     def model_post_init(self, __context) -> None:
@@ -269,6 +270,7 @@ class BrownianMotionPickPlaceEvalConfig(FrankaPickAndPlaceDataGenConfig):
 
     def _init_policy_config(self) -> BrownianMotionPolicyConfig:
         self.policy_config.policy_cls = BrownianMotionPolicy
+        self.policy_config.policy_factory = lambda config, task: BrownianMotionPolicy(config)
         return self.policy_config
 
     def model_post_init(self, __context) -> None:

--- a/molmo_spaces/evaluation/configs/evaluation_configs.py
+++ b/molmo_spaces/evaluation/configs/evaluation_configs.py
@@ -66,6 +66,7 @@ from molmo_spaces.tasks.pick_and_place_task_sampler import (
     PickAndPlaceTaskSampler,
 )
 from molmo_spaces.tasks.task_sampler import BaseMujocoTaskSampler
+from molmo_spaces.utils.function_utils import make_lenient
 
 TIMESTAMP = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
@@ -238,7 +239,7 @@ class DummyPickPlaceEvalConfig(FrankaPickAndPlaceDataGenConfig):
 
     def _init_policy_config(self) -> DummyPolicyConfig:
         self.policy_config.policy_cls = DummyPolicy
-        self.policy_config.policy_factory = lambda config, task: DummyPolicy(config)
+        self.policy_config.policy_factory = make_lenient(DummyPolicy)
         return self.policy_config
 
     def model_post_init(self, __context) -> None:
@@ -270,7 +271,7 @@ class BrownianMotionPickPlaceEvalConfig(FrankaPickAndPlaceDataGenConfig):
 
     def _init_policy_config(self) -> BrownianMotionPolicyConfig:
         self.policy_config.policy_cls = BrownianMotionPolicy
-        self.policy_config.policy_factory = lambda config, task: BrownianMotionPolicy(config)
+        self.policy_config.policy_factory = make_lenient(BrownianMotionPolicy)
         return self.policy_config
 
     def model_post_init(self, __context) -> None:

--- a/molmo_spaces/policy/base_policy.py
+++ b/molmo_spaces/policy/base_policy.py
@@ -94,10 +94,7 @@ class BasePolicy(ABC):
 
 
 # Intended signature: Callable[[MlSpacesExpConfig, BaseMujocoTask | None], BasePolicy].
-# Relaxed to Callable[..., BasePolicy] to avoid forward-reference resolution issues
-# when this alias is used as a Pydantic model field type: MlSpacesExpConfig lives in
-# a module that already imports from this one, so a precise annotation would either
-# require a circular runtime import or fail to be resolved by Pydantic at schema build.
+# Relaxed to Callable[..., BasePolicy] to avoid forward-reference resolution issues with Pydantic.
 PolicyFactory: TypeAlias = Callable[..., BasePolicy]
 
 

--- a/molmo_spaces/policy/base_policy.py
+++ b/molmo_spaces/policy/base_policy.py
@@ -6,7 +6,7 @@ that can interact with the environment to collect data.
 
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, TypeAlias
 
 import numpy as np
 from mujoco import MjSpec
@@ -91,6 +91,14 @@ class BasePolicy(ABC):
             A dictionary of all possible policy phases
         """
         return {"unknown": 0}
+
+
+# Intended signature: Callable[[MlSpacesExpConfig, BaseMujocoTask | None], BasePolicy].
+# Relaxed to Callable[..., BasePolicy] to avoid forward-reference resolution issues
+# when this alias is used as a Pydantic model field type: MlSpacesExpConfig lives in
+# a module that already imports from this one, so a precise annotation would either
+# require a circular runtime import or fail to be resolved by Pydantic at schema build.
+PolicyFactory: TypeAlias = Callable[..., BasePolicy]
 
 
 class PlannerPolicy(BasePolicy):

--- a/molmo_spaces/utils/function_utils.py
+++ b/molmo_spaces/utils/function_utils.py
@@ -1,0 +1,82 @@
+import inspect
+from typing import Callable
+
+
+class _LenientCallable:
+    """Picklable callable returned by :func:`make_lenient`."""
+
+    def __init__(self, func: Callable) -> None:
+        sig = inspect.signature(func)
+        positional: list[str] = []
+        kwonly: set[str] = set()
+        has_varargs = False
+        has_varkw = False
+        for p in sig.parameters.values():
+            if p.kind is inspect.Parameter.VAR_POSITIONAL:
+                has_varargs = True
+            elif p.kind is inspect.Parameter.VAR_KEYWORD:
+                has_varkw = True
+            elif p.kind is inspect.Parameter.KEYWORD_ONLY:
+                kwonly.add(p.name)
+            else:
+                # POSITIONAL_OR_KEYWORD or POSITIONAL_ONLY.
+                positional.append(p.name)
+        self._func = func
+        self._positional_names = positional
+        self._kwonly_names = kwonly
+        self._all_named = frozenset(positional) | kwonly
+        self._has_varargs = has_varargs
+        self._has_varkw = has_varkw
+
+    def __call__(self, *args, **kwargs):
+        n_pos = len(self._positional_names)
+        bound: dict = dict(zip(self._positional_names, args))
+        # Leftover positional args are forwarded to func's *args when present,
+        # otherwise silently dropped.
+        extra_positional = args[n_pos:] if self._has_varargs else ()
+
+        extra_kwargs: dict = {}
+        for name, value in kwargs.items():
+            if name in self._all_named:
+                if name in bound:
+                    raise TypeError(
+                        f"{getattr(self._func, '__qualname__', self._func)!r} "
+                        f"got multiple values for argument {name!r}"
+                    )
+                bound[name] = value
+            elif self._has_varkw:
+                # Forward unmatched kwargs to func's **kwargs.
+                extra_kwargs[name] = value
+            # else: silently dropped
+
+        if extra_positional:
+            # When forwarding to *args, named params before *args must be passed
+            # positionally. Since extra_positional is non-empty, len(args) > n_pos,
+            # so args already covers every positional name. Any kwarg targeting a
+            # positional name would have raised in the loop above, so kwonly params
+            # (and **kwargs forwards) are the only kwargs left to pass.
+            kwonly_for_call = {n: bound[n] for n in self._kwonly_names if n in bound}
+            return self._func(*args, **kwonly_for_call, **extra_kwargs)
+
+        return self._func(**bound, **extra_kwargs)
+
+
+def make_lenient(func: Callable) -> Callable:
+    """
+    Wrap ``func`` so extra args/kwargs are silently dropped.
+
+    Args matching a declared parameter are forwarded; leftover positional and
+    keyword args flow into ``func``'s ``*args`` / ``**kwargs`` when present, and
+    are dropped otherwise. Raises ``TypeError`` on double-binding and (via
+    Python's normal call machinery) on missing required parameters.
+
+    Args:
+        func: The function (or class) to wrap.
+
+    Returns:
+        A picklable callable.
+
+    Note:
+        Positional-only parameters (after ``/``) are not supported.
+    """
+    return _LenientCallable(func)

--- a/scripts/datagen/eval_policy_example.py
+++ b/scripts/datagen/eval_policy_example.py
@@ -63,14 +63,9 @@ def main(args: argparse.ArgumentParser) -> None:
         / f"{exp_config.task_type}_v1"
         / datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     )
-    # exp_config.policy_config = PiPolicyConfig()
-    # policy constructor takes (config, task)
-    # policy = exp_config.policy_config.policy_cls(exp_config, None)
-    # policy.prepare_model()
-    policy = None
     exp_config.save_config()
     runner = MyRunner(exp_config)
-    runner.run(preloaded_policy=policy)
+    runner.run()
 
 
 if __name__ == "__main__":

--- a/scripts/datagen/run_pipeline.py
+++ b/scripts/datagen/run_pipeline.py
@@ -316,7 +316,7 @@ def main(args: argparse.ArgumentParser) -> None:
             exp_config.policy_dt_ms = 40  # More responsive for teleoperation
             exp_config.task_horizon = 1000
         exp_config.policy_config = get_policy_config(args.policy, robot=args.robot)
-        policy = exp_config.policy_config.policy_cls(exp_config)
+        policy = exp_config.policy_config.policy_factory(exp_config, None)
     elif args.policy == "planner":
         pass
     else:

--- a/scripts/grasps/run_grasps_test.py
+++ b/scripts/grasps/run_grasps_test.py
@@ -950,7 +950,7 @@ def test_grasps_for_scene(
                     from molmo_spaces.tasks.pick_task import PickTask
 
                     task = PickTask(task_sampler.env, datagen_cfg)
-                    policy = datagen_cfg.policy_config.policy_cls(datagen_cfg, task)
+                    policy = datagen_cfg.policy_config.policy_factory(datagen_cfg, task)
 
                     # Override _compute_target_poses to use our specific grasp pose
                     def compute_target_poses_with_grasp(self):
@@ -1455,7 +1455,7 @@ def test_grasps_for_scene(
                         from molmo_spaces.tasks.opening_tasks import OpeningTask
 
                         task = OpeningTask(task_sampler.env, datagen_cfg)
-                        policy = datagen_cfg.policy_config.policy_cls(datagen_cfg, task)
+                        policy = datagen_cfg.policy_config.policy_factory(datagen_cfg, task)
 
                         # Set postgrasp_z_offset to 0.05
                         policy.policy_config.postgrasp_z_offset = 0.05


### PR DESCRIPTION
Right now, policy instantiation in the pipeline used `policy_config.policy_cls`, which informally placed a constraint on the acceptable policy constructor type signatures. This isn't ideal, since policies might require different constructors and requiring a specific signature is constraining, and otherwise the only way around it is to pre-instantiate the policy.

This PR fixes this by introducing `policy_config.policy_factory`, which takes in `(config, task)` and returns a policy. For policy impls that have this constructor signature the policy factory is simply the policy class, but otherwise this allows policy implementations to keep this separate.