### PR TITLE
Pin warp version to avoid incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "msgpack-numpy",
     "mujoco-warp~=3.5.0",
     "mujoco-mjx~=3.5.0",
-    "warp-lang<1.15.0",
+    "warp-lang<1.15.0", # warp-lang had breaking changes in 1.15.0 that caused ik tests to fail
     "nbstripout>=0.7.0",
     "nltk~=3.9.2",
     "numpy>=1.19.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "msgpack-numpy",
     "mujoco-warp~=3.5.0",
     "mujoco-mjx~=3.5.0",
+    "warp-lang<1.15.0",
     "nbstripout>=0.7.0",
     "nltk~=3.9.2",
     "numpy>=1.19.0,<3",


### PR DESCRIPTION
Warp 1.15.0 introduced new changes which breaks our warp-based parallel IK implementation. A future PR should update the IK to be future-compatible, but for now pinning warp-lang as <1.15.0 works.