### PR TITLE
Fix RBY1 pick success: root_body_id type + kinematic-tree-root comparison

### DIFF
--- a/molmo_spaces/robots/robot_views/abstract.py
+++ b/molmo_spaces/robots/robot_views/abstract.py
@@ -721,6 +721,17 @@ class RobotView(ABC):
         """The base of the robot."""
         raise NotImplementedError
 
+    @cached_property
+    def root_body_id(self) -> int:
+        """The ID of the root body of the robot's kinematic tree.
+
+        This is not necessarily ``base.root_body_id``: the base move group's root body
+        is the base itself, which may be nested under an outer wrapper body (RBY1's MJCF
+        nests ``robot_0/base`` under ``robot_0/``). Contacts identify a body's tree via
+        ``model.body_rootid``, so comparisons against contact bodies must use this.
+        """
+        return int(self.mj_model.body_rootid[int(self.base.root_body_id)])
+
     def move_group_ids(self) -> list[str]:
         """Get the IDs of all move groups in this robot."""
         return list(self._move_groups.keys())

--- a/molmo_spaces/robots/robot_views/rby1_view.py
+++ b/molmo_spaces/robots/robot_views/rby1_view.py
@@ -96,7 +96,7 @@ class RBY1GripperGroup(MJCFFrameMixin, GripperGroup):
             model.joint(f"{namespace}gripper_finger_{side[0]}{i + 1}").id for i in range(2)
         ]
         act_ids = [model.actuator(f"{namespace}{side}_finger_act").id]
-        root_body_id = model.body(f"{namespace}EE_BODY_{side[0].upper()}")
+        root_body_id = model.body(f"{namespace}EE_BODY_{side[0].upper()}").id
         super().__init__(mj_data, joint_ids, act_ids, root_body_id, base)
         self._ee_site_id = model.site(f"{namespace}ee_site_{side[0]}").id
 
@@ -246,7 +246,7 @@ class RBY1HoloBaseGroup(HoloJointsRobotBaseGroup):
         holo_base_site_id = model.site(f"{namespace}base_site").id
         joints = [model.joint(f"{namespace}base_{axis}").id for axis in ["x", "y", "theta"]]
         act = [model.actuator(f"{namespace}base_{axis}_act").id for axis in ["x", "y", "theta"]]
-        root_body_id = model.body(f"{namespace}base")
+        root_body_id = model.body(f"{namespace}base").id
         super().__init__(mj_data, world_site_id, holo_base_site_id, joints, act, root_body_id)
 
 

--- a/molmo_spaces/tasks/pick_and_place_task.py
+++ b/molmo_spaces/tasks/pick_and_place_task.py
@@ -195,11 +195,7 @@ class PickAndPlaceTask(BaseMujocoTask):
             tilt_displacement = np.arccos(cos_tilt)
 
             # Check that the robot has released the object (no robot-object contact).
-            # Map the base move group's root body to the root of the robot's kinematic
-            # tree; they differ when the robot is nested under an outer body (RBY1).
-            robot_root_body_id = data.model.body_rootid[
-                int(self._env.current_robot.robot_view.base.root_body_id)
-            ]
+            robot_root_body_id = self._env.current_robot.robot_view.root_body_id
             robot_contact = False
             for c in data.contact:
                 root_body1 = data.model.body_rootid[data.model.geom_bodyid[c.geom1]]

--- a/molmo_spaces/tasks/pick_and_place_task.py
+++ b/molmo_spaces/tasks/pick_and_place_task.py
@@ -195,7 +195,11 @@ class PickAndPlaceTask(BaseMujocoTask):
             tilt_displacement = np.arccos(cos_tilt)
 
             # Check that the robot has released the object (no robot-object contact).
-            robot_root_body_id = self._env.current_robot.robot_view.base.root_body_id
+            # Map the base move group's root body to the root of the robot's kinematic
+            # tree; they differ when the robot is nested under an outer body (RBY1).
+            robot_root_body_id = data.model.body_rootid[
+                int(self._env.current_robot.robot_view.base.root_body_id)
+            ]
             robot_contact = False
             for c in data.contact:
                 root_body1 = data.model.body_rootid[data.model.geom_bodyid[c.geom1]]

--- a/molmo_spaces/tasks/pick_task.py
+++ b/molmo_spaces/tasks/pick_task.py
@@ -150,12 +150,7 @@ class PickTask(BaseMujocoTask):
 
             # Option 2: go via root body and check if all contacts are with robot geoms
             # Check if object collides only with robot geoms
-            # The base move group's root body is not necessarily the root of the robot's
-            # kinematic tree (RBY1 nests its base under an outer "robot_0/" body), so map
-            # it through body_rootid to match what geom_bodyid/body_rootid yields below.
-            robot_root_body_id = data.model.body_rootid[
-                int(self.env.current_robot.robot_view.base.root_body_id)
-            ]
+            robot_root_body_id = self.env.current_robot.robot_view.root_body_id
             robot_collision = False
             non_robot_collision = False
             for c in data.contact:

--- a/molmo_spaces/tasks/pick_task.py
+++ b/molmo_spaces/tasks/pick_task.py
@@ -150,6 +150,12 @@ class PickTask(BaseMujocoTask):
 
             # Option 2: go via root body and check if all contacts are with robot geoms
             # Check if object collides only with robot geoms
+            # The base move group's root body is not necessarily the root of the robot's
+            # kinematic tree (RBY1 nests its base under an outer "robot_0/" body), so map
+            # it through body_rootid to match what geom_bodyid/body_rootid yields below.
+            robot_root_body_id = data.model.body_rootid[
+                int(self.env.current_robot.robot_view.base.root_body_id)
+            ]
             robot_collision = False
             non_robot_collision = False
             for c in data.contact:
@@ -157,7 +163,7 @@ class PickTask(BaseMujocoTask):
                 root_body2 = data.model.body_rootid[data.model.geom_bodyid[c.geom2]]
                 if (root_body1 == pickup_obj.body_id) ^ (root_body2 == pickup_obj.body_id):
                     other_root_body = root_body1 if root_body1 != pickup_obj.body_id else root_body2
-                    if other_root_body == self.env.current_robot.robot_view.base.root_body_id:
+                    if other_root_body == robot_root_body_id:
                         robot_collision = True
                     else:
                         non_robot_collision = True

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -147,13 +147,7 @@ class BaseMujocoTask(ABC):
         robot_view = self._env.robots[batch_index].robot_view
         for gripper_mg_id in robot_view.get_gripper_movegroup_ids():
             gripper_mg = robot_view.get_move_group(gripper_mg_id)
-            root_body_id = gripper_mg.root_body_id
-            # Handle both int IDs and body view objects (some robot views store the view directly)
-            if hasattr(root_body_id, "name"):
-                gripper_body_name = root_body_id.name
-            else:
-                gripper_body_name = robot_view.mj_model.body(root_body_id).name
-            objects[gripper_mg_id] = gripper_body_name
+            objects[gripper_mg_id] = robot_view.mj_model.body(gripper_mg.root_body_id).name
 
         added = getattr(self.config.task_config, "added_objects", {})
         for it, (name, _path) in enumerate(added.items()):


### PR DESCRIPTION
## Problem

`PickTask` success is unreachable for RBY1 — it reports 0 for every episode regardless of whether the grasp actually succeeded. Reported in allenai/MolmoBot#9, where the released MolmoBot-RBY1Multitask checkpoint reproduces the Pick&Place / Opening / Door-Opening numbers but scores 0/100 on Pick. A manual review of 51 Pick rollouts in that thread judged ~27% visually successful while the benchmark reported 0.

Two independent defects combine to make the success check always fail. Both are in the contact classification introduced in `cd23bece`:

```python
root_body1 = data.model.body_rootid[data.model.geom_bodyid[c.geom1]]
...
if other_root_body == self.env.current_robot.robot_view.base.root_body_id:
    robot_collision = True
else:
    non_robot_collision = True   # any non-robot contact kills success
```

### 1. `root_body_id` was a body view object, not an int

`RBY1BaseGroup` and the RBY1 gripper EE groups passed `model.body(...)` — a `_MjModelBodyViews` object — where every other robot view passes `model.body(...).id`. `MoveGroup` stores the value as-is, and `int == _MjModelBodyViews` silently evaluates to `False`:

```
np.int32(view.id) == view     -> False
np.int32(view.id) == view.id  -> True
```

(`task.py` already carried a local workaround for this: *"Handle both int IDs and body view objects (some robot views store the view directly)"*.)

### 2. `base.root_body_id` is not the robot's kinematic tree root

Even with the `.id` fix the comparison still never matches, because the two sides mean different things. `body_rootid[...]` is the root of the geom's kinematic tree, while `base.root_body_id` is the base move group's own body. RBY1's MJCF nests the base under an outer wrapper body:

```xml
<body name="robot_0/" pos="0 0 0.005">
  <body name="robot_0/base">
```

Loading `rby1_v1.2_site_control.xml` confirms it:

```
body "robot_0/"     id = 3   parent = 0 (world)
body "robot_0/base" id = 4   parent = 3
body_rootid[robot_0/base]      = 3
body_rootid[robot_0/EE_BODY_R] = 3
base.root_body_id              = 4   ->  never matches
```

So every gripper–object contact fell into the `else` branch and was counted as a *non-robot* collision, making `only_robot_collision` unreachable and pick success permanently 0.

Franka is unaffected because its base is already the tree root, which is why Franka pick benchmarks were never impacted. `PickAndPlaceTask` was affected by the same mismatch at `pick_and_place_task.py:198`, but there the result is negated (`not robot_contact`), so the "robot has released the object" guard was silently disabled rather than blocking success — which is why PnP still produced plausible numbers.

## Fix

1. `rby1_view.py`: add the missing `.id` on the base and gripper EE groups, matching the head group in the same file and all other robot views.
2. `pick_task.py` / `pick_and_place_task.py`: map the base body through `body_rootid` so both sides of the comparison refer to the same kinematic tree root. This is a no-op for robots whose base is already the tree root (Franka) and fixes RBY1.

## Verification

Reproduced the classification on a minimal scene mirroring RBY1's nesting (object held by the gripper, clear of the table):

```
OLD comparison target (base body id)      = 3
NEW comparison target (body_rootid[base]) = 2
only_robot_collision  BEFORE fix -> False   (grasp not detected)
only_robot_collision  AFTER  fix -> True    (grasp detected)
```

Note for reproduction on the MolmoBot pin: both defects exist at `cd23bece` (the commit pinned by MolmoBot's `pyproject.toml`), so this patch needs to be applied on top of the pin when evaluating the released RBY1 checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xtyJfcGQkcA6sv9bRNEZ2