### PR TITLE
made env.step accept chunks, prevents useless intermediate rendering for the open loop rollouts

### DIFF
--- a/molmo_spaces/data_generation/pipeline.py
+++ b/molmo_spaces/data_generation/pipeline.py
@@ -754,7 +754,9 @@ class ParallelRolloutRunner:
                 profiler.start("policy_get_action")
             if datagen_profiler is not None:
                 datagen_profiler.start("policy_get_action")
-            action_cmd = policy.get_action(observation)
+            # An action chunk is a list of actions to be applied open-loop before a
+            # new observation is needed.
+            action_chunk = policy.get_action_chunk(observation) or [policy.get_action(observation)]
             if profiler is not None:
                 profiler.end("policy_get_action")
             if datagen_profiler is not None:
@@ -765,16 +767,17 @@ class ParallelRolloutRunner:
                 profiler.start("task_step")
             if datagen_profiler is not None:
                 datagen_profiler.start("task_step")
-            if action_cmd is None:
+            if action_chunk[0] is None:
                 print("Policy returned None action, ending episode")
                 break
-            observation, reward, terminal, truncated, infos = task.step(action_cmd)
+            observation, reward, terminal, truncated, infos = task.step_chunk(
+                action_chunk, stop_on_success=end_on_success
+            )
+            step_count += len(action_chunk)
             if profiler is not None:
                 profiler.end("task_step")
             if datagen_profiler is not None:
                 datagen_profiler.end("task_step")
-
-            step_count += 1
             # Add termination if succ
             if end_on_success and "success" in infos[0] and infos[0]["success"]:
                 success = True

--- a/molmo_spaces/policy/base_policy.py
+++ b/molmo_spaces/policy/base_policy.py
@@ -6,7 +6,7 @@ that can interact with the environment to collect data.
 
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, TypeAlias
 
 import numpy as np
 from mujoco import MjSpec
@@ -63,6 +63,20 @@ class BasePolicy(ABC):
             The action to take in response to the information.
         """
         pass
+
+    def get_action_chunk(self, observation: Any) -> list[dict[str, Any]] | None:
+        """Return the actions to run before the next observation is needed, or None.
+
+        A single action is a ``dict[str, Any]`` in single-env mode and a
+        ``list[dict[str, Any]]`` (one entry per env) in batched mode. A batched
+        action and a chunk of actions are therefore both lists and cannot be told
+        apart by type, so any variable holding a chunk must say so in its name
+        rather than leaving the distinction to be inferred.
+
+        Returns None if this policy has no chunk to offer, which keeps the caller
+        on its per-step path.
+        """
+        return None
 
     @staticmethod
     def add_auxiliary_objects(config: "MlSpacesExpConfig", spec: MjSpec) -> None:

--- a/molmo_spaces/policy/learned_policy/pi_policy.py
+++ b/molmo_spaces/policy/learned_policy/pi_policy.py
@@ -2,6 +2,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 import cv2
 import numpy as np
@@ -183,6 +184,19 @@ class PI_Policy(InferencePolicy, StatefulPolicy):
             "gripper": gripper_pos,
         }
         return action
+
+    def get_action_chunk(self, observation: Any) -> list[dict[str, np.ndarray]]:
+        """Return the whole predicted chunk, so only its first action needs an observation.
+
+        The model predicts ``chunk_size`` actions per inference. ``get_action``
+        triggers that inference and consumes the first action; the rest are drained
+        from the buffer here. The returned list is a chunk of single-env actions,
+        not one batched action -- see ``BasePolicy.get_action_chunk``.
+        """
+        first_action = self.get_action(observation)
+        buffered_outputs = self.actions_buffer[self.current_buffer_index : self.chunk_size]
+        self.current_buffer_index = self.chunk_size
+        return [first_action] + [self.model_output_to_action(out) for out in buffered_outputs]
 
     def get_info(self) -> dict:
         info = super().get_info()

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -331,8 +331,15 @@ class BaseMujocoTask(ABC):
             # Return current state without stepping
             return self.get_and_cache_all_step_information()
 
+        self._apply_action(actions)
+        return self._observe_and_cache()
+
+    def _apply_action(self, action: dict[str, Any] | list[dict[str, Any]]) -> None:
+        """Apply one action and advance the simulation, without polling sensors."""
+        actions = [action] if isinstance(action, dict) else action
+
         # Check if any action contains a "done" signal
-        for _i, act in enumerate(actions):
+        for act in actions:
             if isinstance(act, dict) and act.get("done", False):
                 act.pop("done")
                 self._done_action_received = True
@@ -340,8 +347,8 @@ class BaseMujocoTask(ABC):
         # Update episode step count
         self.episode_step_count += 1
 
-        for robot, action in zip(self._env.robots, actions, strict=True):
-            robot.update_control(action)
+        for robot, act in zip(self._env.robots, actions, strict=True):
+            robot.update_control(act)
 
         # Physics step (MuJoCo simulation)
         if self._datagen_profiler is not None:
@@ -356,7 +363,12 @@ class BaseMujocoTask(ABC):
         # Store the action for env 0 for ActionSensors
         self.last_action = actions[0] if actions else None
 
-        # Sensor polling (cameras, proprioception, etc.)
+    def _observe_and_cache(
+        self,
+    ) -> tuple[
+        list[dict[str, Any]], NDArray[float], NDArray[bool], NDArray[bool], list[dict[str, Any]]
+    ]:
+        """Poll the sensor suite and record the resulting step."""
         if self._datagen_profiler is not None:
             self._datagen_profiler.start("sensor_polling")
         observation, reward, terminated, truncated, info = self.get_and_cache_all_step_information()
@@ -371,6 +383,37 @@ class BaseMujocoTask(ABC):
         self.action_cache.append(self.last_action)
 
         return observation, reward, terminated, truncated, info
+
+    def step_chunk(
+        self,
+        action_chunk: list[dict[str, Any] | list[dict[str, Any]]],
+        stop_on_success: bool = False,
+    ) -> tuple[
+        list[dict[str, Any]], NDArray[float], NDArray[bool], NDArray[bool], list[dict[str, Any]]
+    ]:
+        """Step a chunk of actions, polling sensors only after the last one.
+
+        An approximation of real-time action chunking: the chunk runs open-loop.
+        Could take ``obs_on_action: int = None`` to also return an intermediate
+        observation.
+
+        Args:
+            action_chunk: Actions to apply in order. Each one is a single action
+                dict for single-env mode, or a list of action dicts for batched mode.
+            stop_on_success: End the chunk once the success criterion is met.
+
+        Returns:
+            Tuple of (observations, rewards, terminated, truncated, infos)
+        """
+        if not action_chunk:
+            raise ValueError("step_chunk requires at least one action")
+
+        for action in action_chunk[:-1]:
+            self._apply_action(action)
+            if np.all(self.is_done()) or (stop_on_success and self.judge_success()):
+                return self._observe_and_cache()
+
+        return self.step(action_chunk[-1])
 
     def is_done(self) -> NDArray[bool]:
         return np.logical_or(self.is_terminal(), self.is_timed_out())


### PR DESCRIPTION
shouldn't affect anything. you can just send one action (as done in the policies previously) and it would carry out old behavior

x3 speed on average

(also this plot was with termination on success = false for fairness, given the policy stochasticity)
 
<img width="700" height="480" alt="sec_per_episode (1)" src="https://github.com/user-attachments/assets/d0a1db5c-87a4-4b04-97ef-60bb30d6b384" />
