### PR TITLE
use mujoco's new default sleep tolerance

### DIFF
--- a/molmo_spaces/data_generation/pipeline.py
+++ b/molmo_spaces/data_generation/pipeline.py
@@ -738,6 +738,8 @@ class ParallelRolloutRunner:
 
         try:
             task.env.current_model.opt.enableflags |= int(mujoco.mjtEnableBit.mjENBL_SLEEP)
+            # mujoco 3.11 raised the default sleep_tolerance from 1e-4 to 1e-3
+            task.env.current_model.opt.sleep_tolerance = 1e-3
         except AttributeError:
             print("Not setting mujoco sleep. Needs version >=mujoco-3.8")
 


### PR DESCRIPTION
Some meshes far from the robot were not sleeping since they we're oscillating with a velocity that exceeds MuJoCo's old default qvel sleeping threshold (not sure why this is happening btw it might. mean objects params need tuning). This just sets the threshold to the one MuJoCo uses as of 3.11 (1e-3) which is a bit higher and does not include them.

<img width="400" alt="sec_per_episode_zoom-2" src="https://github.com/user-attachments/assets/ae71ab62-9741-4276-a7e0-2d564ba5e30a" />
