### PR TITLE
refactor: lazily load wordnet instead of at import time

### DIFF
--- a/molmo_spaces/env/object_manager.py
+++ b/molmo_spaces/env/object_manager.py
@@ -29,8 +29,8 @@ from molmo_spaces.utils.object_metadata import ObjectMeta, clip_sim, compute_tex
 from molmo_spaces.utils.synset_utils import (
     filter_synsets_to_remove_hyponyms,
     generate_all_hypernyms_with_exclusions,
+    get_wordnet,
     is_hypernym_of,
-    wn,
 )
 
 if TYPE_CHECKING:
@@ -437,7 +437,7 @@ class ObjectManager:
         res = []
         seen_versions = set()
 
-        for lemma in wn.synset(synset).lemma_names():
+        for lemma in get_wordnet().synset(synset).lemma_names():
             space = normalize_expression(lemma).strip()
             # lower = space.replace(" ", "")
             # snake = space.replace(" ", "_")
@@ -1095,7 +1095,7 @@ class ObjectManager:
         )
         try:
             sim = clip_sim(img, compute_text_clip(descriptions))
-        except NameError:
+        except ImportError:
             log.warning("No CLIP module, using dummy description scores.")
             # e.g. when you don't want to install it / no gpu (?)
             names = self.get_natural_object_names(object_or_name_or_id, [])

--- a/molmo_spaces/utils/lemma_utils.py
+++ b/molmo_spaces/utils/lemma_utils.py
@@ -2,9 +2,12 @@ import functools
 
 from nltk.corpus.reader.wordnet import Synset
 
-from molmo_spaces.utils.synset_utils import wn
+from molmo_spaces.utils.synset_utils import get_wordnet
 
-PHYSICAL_ENTITY_SYNSET = wn.synset("physical_entity.n.01")
+
+@functools.cache
+def _physical_entity_synset() -> Synset:
+    return get_wordnet().synset("physical_entity.n.01")
 
 
 def normalize_expression(text: str) -> str:
@@ -16,12 +19,14 @@ def normalize_expression(text: str) -> str:
 
 def is_physical_entity(synset: Synset | str) -> bool:
     if isinstance(synset, str):
-        synset = wn.synset(synset)
-    return PHYSICAL_ENTITY_SYNSET in synset.lowest_common_hypernyms(PHYSICAL_ENTITY_SYNSET)
+        synset = get_wordnet().synset(synset)
+    physical_entity = _physical_entity_synset()
+    return physical_entity in synset.lowest_common_hypernyms(physical_entity)
 
 
 @functools.lru_cache(maxsize=1000)
 def best_lemma_via_specificity(synset_str: str, enforce_physical_entity: bool = True) -> str:
+    wn = get_wordnet()
     synset = wn.synset(synset_str)
     cur_synset_is_physical_entity = is_physical_entity(synset)
     min_num_synsets = 100000
@@ -44,4 +49,4 @@ def best_lemma_via_specificity(synset_str: str, enforce_physical_entity: bool = 
 
 
 def simple_lemma(synset_str: str) -> str:
-    return wn.synset(synset_str).lemma_names()[0]
+    return get_wordnet().synset(synset_str).lemma_names()[0]

--- a/molmo_spaces/utils/synset_utils.py
+++ b/molmo_spaces/utils/synset_utils.py
@@ -2,21 +2,33 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Sequence
 from functools import cache, lru_cache
 
-
-def _ensure_nltk():
-    import nltk
-
-    for corpus in ["wordnet", "wordnet2022"]:
-        nltk.download(corpus)
-
-
-_ensure_nltk()
-
-from nltk.corpus import wordnet2022 as wn
-
-wn.abspaths()
-
 from nltk.corpus.reader import Synset
+
+_WORDNET = None
+
+
+def get_wordnet():
+    """Lazily download NLTK's wordnet corpora and return the wordnet2022 module.
+
+    Downloading/importing wordnet is deferred to first actual use (rather than
+    module import time) since this module is imported by config/env code that
+    loads on every entry point invocation, regardless of whether any wordnet
+    lookup is ever performed.
+    """
+    global _WORDNET
+    if _WORDNET is None:
+        import nltk
+
+        for corpus in ["wordnet", "wordnet2022"]:
+            nltk.download(corpus)
+
+        from nltk.corpus import wordnet2022 as wn
+
+        wn.abspaths()
+        _WORDNET = wn
+
+    return _WORDNET
+
 
 from molmo_spaces.utils.constants.object_constants import AI2THOR_OBJECT_TYPE_TO_WORDNET_SYNSET
 from molmo_spaces.utils.object_metadata import ObjectMeta
@@ -916,7 +928,7 @@ def generate_all_hypernyms_with_exclusions(
         return set()
 
     if isinstance(synset, str):
-        synset = wn.synset(synset)
+        synset = get_wordnet().synset(synset)
 
     return set(
         h
@@ -929,10 +941,10 @@ def generate_all_hypernyms_with_exclusions(
 @lru_cache(maxsize=10000, typed=True)
 def is_hypernym_of(synset: str | Synset, possible_hypernym: str | Synset) -> bool:
     if isinstance(synset, str):
-        synset = wn.synset(synset)
+        synset = get_wordnet().synset(synset)
 
     if isinstance(possible_hypernym, str):
-        possible_hypernym = wn.synset(possible_hypernym)
+        possible_hypernym = get_wordnet().synset(possible_hypernym)
 
     return possible_hypernym in synset.lowest_common_hypernyms(possible_hypernym)
 
@@ -954,14 +966,14 @@ def generate_hypernym_to_descendants(
         return {}
 
     if isinstance(synsets[0], str):
-        synsets = [wn.synset(s) for s in synsets]
+        synsets = [get_wordnet().synset(s) for s in synsets]
 
     synsets = set(synsets)
     synsets = [s.name() for s in synsets]
 
     hypernym_to_descendants = defaultdict(list)
     for s in synsets:
-        s = wn.synset(s)
+        s = get_wordnet().synset(s)
         paths = s.hypernym_paths()
         for hypernym in set(sum(paths, [])):
             hypernym_to_descendants[hypernym.name()].append(s)
@@ -994,7 +1006,7 @@ def get_all_synsets_in_metadata() -> list[Synset]:
     synsets = set(ann["synset"] for ann in anns.values() if "synset" in ann) | set(
         AI2THOR_OBJECT_TYPE_TO_WORDNET_SYNSET.values()
     )
-    synsets = sorted(list(set([wn.synset(s) for s in synsets])), key=lambda s: s.name())
+    synsets = sorted(list(set([get_wordnet().synset(s) for s in synsets])), key=lambda s: s.name())
     return synsets
 
 
@@ -1006,7 +1018,7 @@ def get_hypernym_to_descendants_for_all_metadata_synsets():
 @lru_cache(maxsize=10000, typed=True)
 def get_hyponyms_of_synset(synset: str | Synset, return_strings: bool) -> set[Synset] | set[str]:
     if isinstance(synset, str):
-        synset = wn.synset(synset)
+        synset = get_wordnet().synset(synset)
 
     if return_strings:
         hyps = {synset.name()}
@@ -1050,7 +1062,7 @@ def get_highest_relevant_hypernym(
     excluded: set[str] | str = EXCLUDED_HYPERNYMS,
 ) -> Synset:
     if isinstance(synset, str):
-        synset = wn.synset(synset)
+        synset = get_wordnet().synset(synset)
 
     for hpath in synset.hypernym_paths():
         for hyp in hpath:
@@ -1217,7 +1229,7 @@ PICKUPABLE_EXCLUDED_EXACT_SYNSETS: dict[str, str] = {
 
 def canonical_lemma(synset_name: str) -> str:
     """Return the first (most canonical) lemma for a WordNet synset name."""
-    return wn.synset(synset_name).lemma_names()[0].replace("_", " ")
+    return get_wordnet().synset(synset_name).lemma_names()[0].replace("_", " ")
 
 
 def _build_pickupable_category_exclusion_set() -> dict[str, str]:


### PR DESCRIPTION
## Summary
Split out of `interactive_shell` (commit a2d6b56) into its own PR for standalone review.

`nltk.download()` + the `wordnet2022` import + `wn.abspaths()` ran unconditionally at module import time in `synset_utils.py`, so any import of it (transitively pulled in by config/env code on every entry point invocation) triggered an NLTK corpus check regardless of whether wordnet was ever actually used.

Moves it behind a `get_wordnet()` accessor, cached after first call, so it's only touched by code paths that actually resolve a synset. `lemma_utils.py` and `object_manager.py` (the only other direct consumers of the module-level `wn` name) are updated to fetch it lazily too.

## Test plan
- [x] Cherry-picked cleanly onto `main` (one file auto-merged, no conflicts)
- [x] Importing `synset_utils`/the full config chain no longer triggers an nltk download
- [x] `canonical_lemma()` (and other wordnet-dependent calls) still work correctly on first actual use
- [x] `mlspaces_tests/component_tests/` (73 tests) passes
- [x] `ruff check`/`ruff format --check` clean on all three touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)