### PR TITLE
Add referral_expression_clip_filter config flag, defer CLIP import

### DIFF
--- a/mlspaces_tests/data_generation/test_franka_pick.py
+++ b/mlspaces_tests/data_generation/test_franka_pick.py
@@ -51,6 +51,10 @@ def droid_config():
     config.use_passive_viewer = False
     config.profile = True
     config.use_wandb = False
+    # Saved reference data (task_description, etc.) was generated with CLIP-based
+    # referral expression filtering on; keep it on here so this test doesn't drift
+    # from that fixture now that it defaults to off.
+    config.task_sampler_config.referral_expression_clip_filter = True
     return config
 
 
@@ -62,6 +66,10 @@ def randomized_config():
     config.use_passive_viewer = False
     config.profile = True
     config.use_wandb = False
+    # Saved reference data (task_description, etc.) was generated with CLIP-based
+    # referral expression filtering on; keep it on here so this test doesn't drift
+    # from that fixture now that it defaults to off.
+    config.task_sampler_config.referral_expression_clip_filter = True
     return config
 
 

--- a/molmo_spaces/configs/task_sampler_configs.py
+++ b/molmo_spaces/configs/task_sampler_configs.py
@@ -82,6 +82,14 @@ class PickTaskSamplerConfig(ObjectCentricTaskSamplerConfig):
         None  # Will be set by importing module to avoid circular imports
     )
 
+    # When False (default), referral expressions skip CLIP similarity scoring
+    # entirely -- never calls ObjectManager.referral_expression_priority() (which
+    # lazily imports open_clip and downloads its ViT-L-14 checkpoint on first
+    # use) and just uses the pickup object's plain fallback expression instead.
+    # Set True to prioritize referring expressions by CLIP similarity margin
+    # against distractor objects (requires open_clip installed).
+    referral_expression_clip_filter: bool = False
+
     task_batch_size: int = 1
 
     place_target_name: str | None = None  # Placement target will be added to the scene

--- a/molmo_spaces/tasks/opening_task_samplers.py
+++ b/molmo_spaces/tasks/opening_task_samplers.py
@@ -89,9 +89,14 @@ class OpenTaskSampler(PickTaskSampler):
         # Note: choosing a referral expression via sampling
         om = env.object_managers[env.current_batch_index]
         context_objects = om.get_context_objects(pickup_obj_name, Context.OBJECT)
-        try:
-            expression_priority = om.referral_expression_priority(pickup_obj_name, context_objects)
-        except ValueError:
+        if self.config.task_sampler_config.referral_expression_clip_filter:
+            try:
+                expression_priority = om.referral_expression_priority(
+                    pickup_obj_name, context_objects
+                )
+            except (ValueError, ImportError):
+                expression_priority = [(1.0, 1.0, om.fallback_expression(pickup_obj_name))]
+        else:
             expression_priority = [(1.0, 1.0, om.fallback_expression(pickup_obj_name))]
         self.config.task_config.referral_expressions["pickup_obj_name"] = om.sample_expression(
             expression_priority

--- a/molmo_spaces/tasks/pick_task_sampler.py
+++ b/molmo_spaces/tasks/pick_task_sampler.py
@@ -759,16 +759,24 @@ class PickTaskSampler(BaseMujocoTaskSampler):
         if self._datagen_profiler is not None:
             self._datagen_profiler.start("generate_context_expressions")
 
-        try:
-            expression_priority = om.referral_expression_priority(pickup_obj_name, context_objects)
-            filtered_expression_priority = om.thresholded_expression_priority(expression_priority)
-            if len(filtered_expression_priority) == 0:
-                log.info(
-                    f"No filtered expression priorities for {pickup_obj_name}, "
-                    f"using unfiltered ({len(expression_priority)} expressions)"
+        if self.config.task_sampler_config.referral_expression_clip_filter:
+            try:
+                expression_priority = om.referral_expression_priority(
+                    pickup_obj_name, context_objects
                 )
+                filtered_expression_priority = om.thresholded_expression_priority(
+                    expression_priority
+                )
+                if len(filtered_expression_priority) == 0:
+                    log.info(
+                        f"No filtered expression priorities for {pickup_obj_name}, "
+                        f"using unfiltered ({len(expression_priority)} expressions)"
+                    )
+                    filtered_expression_priority = expression_priority
+            except ImportError:
+                expression_priority = [(1.0, 1.0, om.fallback_expression(pickup_obj_name))]
                 filtered_expression_priority = expression_priority
-        except NameError:
+        else:
             expression_priority = [(1.0, 1.0, om.fallback_expression(pickup_obj_name))]
             filtered_expression_priority = expression_priority
 

--- a/molmo_spaces/utils/object_metadata.py
+++ b/molmo_spaces/utils/object_metadata.py
@@ -9,16 +9,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from filelock import FileLock
-from tqdm import tqdm
-
-from molmo_spaces.utils.lazy_loading_utils import UserAssetLibraryIndexEntry, get_user_library_index
-
-try:
-    import open_clip
-except ImportError:
-    print("Try `pip install open-clip-torch` for open_clip")
-
 from molmospaces_resources import PickleLMDBMap
+from tqdm import tqdm
 
 from molmo_spaces.molmo_spaces_constants import (
     ASSETS_DIR,
@@ -26,6 +18,7 @@ from molmo_spaces.molmo_spaces_constants import (
     USER_ASSET_LIBRARIES,
     get_resource_manager,
 )
+from molmo_spaces.utils.lazy_loading_utils import UserAssetLibraryIndexEntry, get_user_library_index
 
 
 def get_metadata_lmdb_dir():
@@ -59,9 +52,18 @@ def get_annotation():
 
 
 def get_clip_model():
+    """Lazily load open_clip's model/tokenizer -- and lazily import open_clip
+    itself. open_clip (plus its ViT-L-14 checkpoint download) is a heavy
+    optional dependency; nothing above this function touches it, so simply
+    importing this module (needed pervasively for ObjectMeta, which only
+    reads precomputed embeddings/JSON metadata) never imports open_clip.
+    Only code paths that actually need to embed new text at runtime -- see
+    compute_text_clip -- reach this function at all."""
     global _CLIP
 
     if _CLIP is None:
+        import open_clip
+
         clip_model, _, clip_preprocess = open_clip.create_model_and_transforms(
             DEFAULT_CLIP_MODEL, pretrained=DEFAULT_CLIP_PRETRAIN, device=DEFAULT_DEVICE
         )


### PR DESCRIPTION
## Summary
- Adds `referral_expression_clip_filter: bool = False` to `PickTaskSamplerConfig` (shared by pick and opening task samplers). When `False` (default), both call sites skip `ObjectManager.referral_expression_priority()` entirely and use the plain fallback expression instead — no CLIP involved.
- Moves `object_metadata.py`'s `import open_clip` from module level into `get_clip_model()`, so merely importing the module (needed pervasively for `ObjectMeta`, which only reads precomputed embeddings/JSON metadata) never imports `open_clip`; only an actual `compute_text_clip()` call does. A missing `open_clip` package now raises a normal `ImportError` instead of a confusing `NameError`.
- Pins `referral_expression_clip_filter=True` explicitly on the droid and randomized `franka_pick` test configs, since their saved reference data was generated with CLIP filtering on and would otherwise drift now that the flag defaults to off.

## Test plan
- [x] `mlspaces_tests/data_generation/test_franka_pick.py` fixtures pinned to match existing reference data
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)