### PR TITLE
tests: re-seed task samplers right before sampling (defensive hardening)

### DIFF
--- a/mlspaces_tests/data_generation/test_franka_pick.py
+++ b/mlspaces_tests/data_generation/test_franka_pick.py
@@ -79,6 +79,12 @@ def droid_task_sampler(droid_config):
     task_sampler_config = droid_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(droid_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()
@@ -97,6 +103,12 @@ def randomized_task_sampler(randomized_config):
     task_sampler_config = randomized_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(randomized_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()

--- a/mlspaces_tests/data_generation/test_franka_pick_and_place.py
+++ b/mlspaces_tests/data_generation/test_franka_pick_and_place.py
@@ -70,6 +70,12 @@ def droid_task_sampler(droid_config):
     task_sampler_config = droid_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(droid_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()
@@ -126,6 +132,12 @@ def gopro_task_sampler(gopro_config):
     task_sampler_config = gopro_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(gopro_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()

--- a/mlspaces_tests/data_generation/test_rum_open_close.py
+++ b/mlspaces_tests/data_generation/test_rum_open_close.py
@@ -59,6 +59,12 @@ def rum_open_task_sampler(rum_open_config):
     task_sampler_config = rum_open_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(rum_open_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()
@@ -120,6 +126,12 @@ def rum_close_task_sampler(rum_close_config):
     task_sampler_config = rum_close_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(rum_close_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()

--- a/mlspaces_tests/data_generation/test_rum_pick.py
+++ b/mlspaces_tests/data_generation/test_rum_pick.py
@@ -54,6 +54,12 @@ def rum_task_sampler(rum_config):
     task_sampler_config = rum_config.task_sampler_config
     task_sampler_class = task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(rum_config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()

--- a/mlspaces_tests/data_generation_curobo/test_rby1_door_opening.py
+++ b/mlspaces_tests/data_generation_curobo/test_rby1_door_opening.py
@@ -72,6 +72,12 @@ def task_sampler(config):
     """Create and initialize task sampler once for all tests (expensive initialization)."""
     task_sampler_class = config.task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()

--- a/mlspaces_tests/data_generation_curobo/test_rby1_pnp.py
+++ b/mlspaces_tests/data_generation_curobo/test_rby1_pnp.py
@@ -71,6 +71,12 @@ def task_sampler(config):
     """Create and initialize task sampler once for all tests (expensive initialization)."""
     task_sampler_class = config.task_sampler_config.task_sampler_class
     task_sampler = task_sampler_class(config)
+    # Re-seed right before sampling starts, so this test's determinism is
+    # anchored at the moment sampling begins rather than depending on anything
+    # that happened earlier in __init__ (env/resource-manager setup). This is
+    # a defensive hardening, not a root-cause fix for a specific known issue --
+    # see PR discussion for what's actually been ruled in/out.
+    task_sampler.seed_task_sampling(task_sampler.current_seed)
     task_sampler.reset()
     yield task_sampler
     task_sampler.env.close()


### PR DESCRIPTION
## Summary
- **Not a confirmed root-cause fix** -- see investigation below. This is a defensive hardening: re-apply `task_sampler.seed_task_sampling(task_sampler.current_seed)` immediately before `task_sampler.reset()` in every task_sampler fixture that has this pattern, so each test's deterministic sampling is anchored at the moment sampling begins rather than depending on exactly what happened earlier in `__init__`.
- Applied to: `test_rby1_door_opening.py`, `test_rby1_pnp.py` (data_generation_curobo), and `test_rum_pick.py`, `test_rum_open_close.py` (x2), `test_franka_pick.py` (x2), `test_franka_pick_and_place.py` (x2) (data_generation) -- 8 fixtures across 6 files.

## Motivation / investigation
Triggered by `main`'s `data-generation-curobo-tests` failing on `test_rby1_door_opening.py::test_policy_determinism` right after #165 merged (`b89e9de` green -> `a4cd2b5` red, and `git log b89e9de..a4cd2b5` is exactly that one commit). The failure: final base pose (indices 0-2) off by 0.02-0.14 (tolerance `2e-2`), while every other joint (arms/gripper/torso) matched to `1e-3`-`1e-8` -- i.e. the policy/controller itself behaved identically, only the sampled starting pose differed.

**Ruled out:** an RNG-stream-shift theory (new `humans_rocketbox` registration changing how much randomness gets consumed during setup). Disproven because:
- Every affected test sets `house_inds` explicitly, so `_get_dataset_index_map()` -- the only thing in `__init__`'s pre-seed window that touches asset/scene enumeration -- never runs.
- `molmospaces-resources` (the actual resource-manager package) has zero references to `random`/`np.random`/`seed` anywhere in its source.

**Strongest actual lead (unconfirmed):** #165's diff also bumped `pyproject.toml`'s `molmospaces-resources==0.0.1b4` -> `==0.0.2` -- tags that are 5 months and 9 releases apart, a gap this pin had never tracked before. The failing test's golden array is loaded via `get_resource_manager()` from that exact package. However, diffing the package's actual code between those two tags shows no change to existing data-resolution/caching logic for already-registered sources (only new `humans_rocketbox` registration, a new `GCRemoteStorage` class, and new unrelated downloader scripts) -- and the real scene/test-data blobs live outside this repo in remote storage, so I can't confirm whether the content behind an unchanged version-pin string changed. It's also possible this is genuine GPU/curobo floating-point non-determinism (this test suite already has a `# high GPU variance is killing me` comment elsewhere acknowledging that class of issue).

Given I don't have GPU/CI access to fetch-and-diff the actual `.npy` bytes or reproduce the curobo run, I can't go further than this. The re-seed change is safe and reasonable regardless, but shouldn't be read as "the fix" for the CI failure without someone with CI/GPU access confirming.

## Test plan
- [x] `ruff check`/`ruff format --check` clean on all 6 changed files
- [x] Syntax-validated all 6 changed files
- [ ] CI: `data-generation-curobo-tests` and `data-generation-tests` -- unverified locally (no GPU/curobo; local env's `molmospaces-resources` predates the 0.0.2 minimum #165 introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)