### PR TITLE
image resolution 640x368

### DIFF
--- a/examples/add_robot/xarm7_datagen.py
+++ b/examples/add_robot/xarm7_datagen.py
@@ -10,7 +10,7 @@ from molmo_spaces.tasks.pick_task_sampler import PickTaskSampler
 
 
 class XArm7CameraSystem(CameraSystemConfig):
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
 
     cameras: list[AllCameraTypes] = [
         MjcfCameraConfig(

--- a/molmo_spaces/configs/camera_configs.py
+++ b/molmo_spaces/configs/camera_configs.py
@@ -307,7 +307,7 @@ class FrankaRandomizedD405D455CameraSystem(CameraSystemConfig):
     runtime information without modifying the camera config.
     """
 
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
     cameras: list[AllCameraTypes] = [
         # Wrist-mounted camera
         MjcfCameraConfig(
@@ -359,7 +359,7 @@ class FrankaDroidCameraSystem(CameraSystemConfig):
 
     img_resolution: tuple[int, int] = (
         640,
-        360,
+        368,
     )  # 16:9 aspect ratio and divisible by 16px for video encoding
     cameras: list[AllCameraTypes] = [
         # Wrist-mounted camera (with depth for D405 simulation)
@@ -393,7 +393,7 @@ class FrankaEasyRandomizedDroidCameraSystem(CameraSystemConfig):
     runtime information without modifying the camera config.
     """
 
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
     cameras: list[AllCameraTypes] = [
         # Wrist-mounted camera
         MjcfCameraConfig(
@@ -444,7 +444,7 @@ class FrankaOmniPurposeCameraSystem(CameraSystemConfig):
     runtime information without modifying the camera config.
     """
 
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
     cameras: list[AllCameraTypes] = [
         # Wrist-mounted camera
         MjcfCameraConfig(
@@ -524,7 +524,7 @@ class FrankaRandomizedDroidCameraSystem(CameraSystemConfig):
     runtime information without modifying the camera config.
     """
 
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
     cameras: list[AllCameraTypes] = [
         # Wrist-mounted camera
         MjcfCameraConfig(
@@ -770,7 +770,7 @@ class BimanualYamCameraSystem(CameraSystemConfig):
     The exo camera is positioned slightly back and higher to capture both arms.
     """
 
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
     cameras: list[AllCameraTypes] = [
         # Left wrist camera (defined in yam.xml, attached to left_link_6)
         MjcfCameraConfig(
@@ -823,7 +823,7 @@ class FrankaEvalCameraSystem(CameraSystemConfig):
     Exo camera pos/forward/up are placeholders; the runtime loads stored poses from episode specs.
     """
 
-    img_resolution: tuple[int, int] = (640, 360)
+    img_resolution: tuple[int, int] = (640, 368)
 
     ref_level_ranges: ClassVar[
         list[tuple[float, dict[str, dict[str, float | tuple[float, ...]]]]]

--- a/scripts/benchmarks/patch_benchmarks.py
+++ b/scripts/benchmarks/patch_benchmarks.py
@@ -44,13 +44,13 @@ log = logging.getLogger(__name__)
 CAMERA_SYSTEM_IMG_RESOLUTIONS: dict[str, tuple[int, int]] = {
     "RBY1MjcfCameraSystem": (640, 480),
     "RBY1GoProD455CameraSystem": (1024, 576),
-    "FrankaRandomizedD405D455CameraSystem": (640, 360),
-    "FrankaDroidCameraSystem": (640, 360),
-    "FrankaEasyRandomizedDroidCameraSystem": (640, 360),
-    "FrankaRandomizedDroidCameraSystem": (640, 360),
+    "FrankaRandomizedD405D455CameraSystem": (640, 368),
+    "FrankaDroidCameraSystem": (640, 368),
+    "FrankaEasyRandomizedDroidCameraSystem": (640, 368),
+    "FrankaRandomizedDroidCameraSystem": (640, 368),
     "FrankaGoProD405D455CameraSystem": (640, 480),
     "FrankaGoProD405RandomizedCameraSystem": (640, 480),
-    "FrankaOmniPurposeCameraSystem": (640, 360),
+    "FrankaOmniPurposeCameraSystem": (640, 368),
 
 }
 


### PR DESCRIPTION
## Summary
- H.264 video encoding requires frame dimensions divisible by 16px. Empirically confirmed (via `cv2.VideoCapture` and `imageio.v3.imread`, both independently) that a pick-datagen episode configured with `img_resolution=(640, 360)` actually saves video files at **640x368** on disk — 360 is not divisible by 16 and gets silently rounded up during `.mp4` encoding.
- Updated all default `img_resolution=(640, 360)` declarations to `(640, 368)` so the config matches what's actually written to disk: 7 camera-system classes in `molmo_spaces/configs/camera_configs.py`, the tutorial example `examples/add_robot/xarm7_datagen.py`, and the `CAMERA_SYSTEM_IMG_RESOLUTIONS` metadata map in `scripts/benchmarks/patch_benchmarks.py` (used to backfill benchmark JSON metadata from the camera class).
- Re-ran the pipeline with the new `(640, 368)` default and confirmed the saved video is exactly 640x368 (368 is divisible by 16, so no further rounding occurs).
- Left `mlspaces_tests/data_generation/config.py`'s test-data resolution at its original `(624, 352)` (already divisible by 16, unaffected) and did not touch `bimanual_yam_pi_policy.py`'s `[360, 640, 3]` shapes, which describe an externally pretrained LeRobot checkpoint's training data format and are unrelated to this repo's camera configs.

## Test plan
- [x] `run_pipeline.py` pick-datagen episode re-run with updated defaults; confirmed saved `.mp4` is 640x368 via both `cv2.VideoCapture` and `imageio.v3.imread`.
- [x] `ruff check` / `ruff format --check` pass on both linted files (`camera_configs.py`, `xarm7_datagen.py`); `scripts/` is excluded from ruff per `pyproject.toml`.
- [x] Repo-wide grep (including multi-line tuple formats) confirms no remaining `(640, 360)` occurrences outside the intentionally-excluded files above.