### PR TITLE
 task_gym_env (v1)

### DIFF
--- a/docs/gym_compatibility.md
+++ b/docs/gym_compatibility.md
@@ -1,0 +1,116 @@
+# Gym Compatibility
+
+Tasks (`BaseMujocoTask`) subclass `gymnasium.Env`, and can be built through
+`gymnasium.make`. The compatibility is **deliberately partial**: the parts that
+would need to change the data generation path were left alone. Read this before
+pointing third-party RL code at a molmospaces env.
+
+## Two ways to build a task
+
+```python
+# 1. Data generation / evaluation: the sampler builds the task (unchanged).
+task_sampler = exp_config.task_sampler_config.task_sampler_class(exp_config)
+task = task_sampler.sample_task()
+
+# 2. Gymnasium: the task builds itself, creating its own sampler.
+task = exp_config.task_config.task_cls(exp_config=exp_config, configure=True)
+
+# 3. Gymnasium, via registration.
+import molmo_spaces.tasks.gym_registration as gym_registration
+gym_registration.register_configs()
+env = gymnasium.make("MolmoSpaces/FrankaPickDroidDataGenConfig-v0")
+```
+
+Env ids come from the data generation config registry, so any config registered
+with `@register_config` is available as `MolmoSpaces/<ConfigName>-v0`.
+
+## What does not hold
+
+### No `action_space`
+
+Actions are dicts keyed by move group (`{"arm": ..., "gripper": ...}`), and no
+space describes them. Consequences:
+
+- `gymnasium.utils.env_checker.check_env` fails.
+- Most wrappers and RL libraries (Stable-Baselines3, CleanRL, RLlib) raise on
+  construction, since they read `action_space` unconditionally. Registered envs
+  therefore set `disable_env_checker=True`.
+
+If you need one, write an adapter that declares a space for your robot and
+translates arrays to the action dict; it is not provided because the useful
+shape (flat `Box` vs nested `Dict`) depends on the consumer.
+
+### No `observation_space`
+
+Individual sensors carry `gymnasium` spaces (`sensor.observation_space`, and
+`sensor_suite.observation_spaces`), but observations returned by `reset()` and
+`step()` are `list[dict]` -- one dict per batch element -- so no single space
+describes them. Rather than declare a space that
+`observation_space.contains(obs)` would reject, none is declared.
+
+The observation contract is also **not fixed for a config**: robot sensors are
+added at construction, `register_policy()` adds policy sensors, and some sensors
+size themselves from the sampled episode's objects.
+
+### Single environment only
+
+The gymnasium path requires `n_batch == 1` and raises otherwise. Batched task
+state exists (`step()` returns arrays over the batch), but termination and
+success are index-0 only, so batching is not usable end-to-end. There is no
+`gymnasium.vector.VectorEnv` implementation; use the task sampler directly for
+batches.
+
+### `reset(seed=...)` seeds process-global RNG
+
+`seed` is forwarded to `BaseMujocoTaskSampler.seed_task_sampling`, which calls
+`random.seed`, `np.random.seed` and `torch.manual_seed`. **It reseeds the whole
+process**, including the RNG of the code that called `reset` -- so seeding an env
+per episode will also reset your policy's exploration noise.
+
+This is because the samplers draw from the global `random`/`np.random` modules
+in ~70 places; localizing that would change every sampled episode and redefine
+what `config.seed` reproduces. `reset()` without a seed touches no RNG.
+
+### `reset()` semantics depend on how the task was built
+
+| Built via | `reset()` does |
+| --- | --- |
+| `configure=True` (gym) | Samples a **new** episode, except the first call, which uses the episode built during construction. Pass `seed` or `options` to force a re-sample. |
+| `sample_task()` (datagen) | Clears task state only; the scene and episode are untouched. A new episode means another `sample_task()`. |
+
+`options` accepts only `house_index` and `force_advance_scene`; anything else
+raises.
+
+### Reset can be expensive
+
+A reset that crosses a house boundary loads a scene and recompiles the MuJoCo
+model, which takes seconds. Callers that assume a cheap reset will see spikes.
+Note also that loading a scene **replaces** the underlying `CPUMujocoEnv`, so
+never cache `task.env` across a reset.
+
+### No cross-env scene reuse
+
+Each gym env owns its own sampler and therefore its own sim env, so N parallel
+envs each pay their own scene loads. Samplers cannot be shared between live envs:
+a sampler holds exactly one sim env, and one env's reset would mutate the other's
+scene.
+
+## What does hold
+
+- `isinstance(task, gymnasium.Env)`, `task.unwrapped`, `task.np_random`.
+- `reset(*, seed=None, options=None)` returning `(observation, info)`.
+- `step(action)` returning `(observation, reward, terminated, truncated, info)`.
+- `render()` returning an RGB `uint8` array, from `render_camera` if set or the
+  first configured camera otherwise. `metadata["render_modes"] == ["rgb_array"]`.
+  Unlike `gym.Env.render`, it does not require `render_mode` to be set.
+- `close()`, which closes the sampler only when the task created it -- a
+  caller-supplied sampler is never closed underneath the caller.
+- Both construction paths produce the **same observation keys**, which is covered
+  by a test.
+
+## Tests
+
+`mlspaces_tests/data_generation/test_gym_env_interface.py` covers the gym path,
+cross-path observation parity, reset semantics for both paths, the batched
+rejection, sampler exhaustion (`EpisodesExhausted` rather than `None`), render,
+registration, and the deliberate absence of both spaces.

--- a/docs/gym_compatibility.md
+++ b/docs/gym_compatibility.md
@@ -12,8 +12,9 @@ pointing third-party RL code at a molmospaces env.
 task_sampler = exp_config.task_sampler_config.task_sampler_class(exp_config)
 task = task_sampler.sample_task()
 
-# 2. Gymnasium: the task builds itself, creating its own sampler.
-task = exp_config.task_config.task_cls(exp_config=exp_config, episode_source="self")
+# 2. Gymnasium: omit the env and the task builds itself, creating its own
+#    sampler. NOTE this samples an episode, so it can load a scene.
+task = exp_config.task_config.task_cls(exp_config=exp_config)
 
 # 3. Gymnasium, via registration.
 import molmo_spaces.tasks.gym_registration as gym_registration
@@ -75,11 +76,20 @@ what `config.seed` reproduces. `reset()` without a seed touches no RNG.
 
 | Built via | `reset()` does |
 | --- | --- |
-| `episode_source="self"` (gym) | Samples a **new** episode, except the first call, which uses the episode built during construction. Pass `seed` or `options` to force a re-sample. |
-| `episode_source="sampler"`, via `sample_task()` (datagen) | Clears task state only; the scene and episode are untouched. A new episode means another `sample_task()`. |
+| `EpisodeSource.SELF` (no env passed; gym) | Samples a **new** episode, except the first call, which uses the episode built during construction. Pass `seed` or `options` to force a re-sample. |
+| `EpisodeSource.SAMPLER` (env passed, via `sample_task()`; datagen) | Clears task state only; the scene and episode are untouched. A new episode means another `sample_task()`. |
 
-`options` accepts only `house_index` and `force_advance_scene`; anything else
-raises.
+`options` is forwarded to `BaseMujocoTaskSampler.prepare_episode`, so
+`house_index` and `force_advance_scene`; anything else is that function's
+`TypeError`.
+
+`episode_source` is derived, not passed: an `env` argument means a sampler built
+the episode, no `env` means the task samples its own.
+
+Re-sampling is not unbounded. Samplers consume their per-house candidate pool, so
+enough resets on one house eventually raise `HouseInvalidForTask` -- the same
+signal data generation handles by advancing houses. Gym callers should be ready
+to catch it, or pass `options={"force_advance_scene": True}`.
 
 ### Reset can be expensive
 

--- a/docs/gym_compatibility.md
+++ b/docs/gym_compatibility.md
@@ -13,7 +13,7 @@ task_sampler = exp_config.task_sampler_config.task_sampler_class(exp_config)
 task = task_sampler.sample_task()
 
 # 2. Gymnasium: the task builds itself, creating its own sampler.
-task = exp_config.task_config.task_cls(exp_config=exp_config, configure=True)
+task = exp_config.task_config.task_cls(exp_config=exp_config, episode_source="self")
 
 # 3. Gymnasium, via registration.
 import molmo_spaces.tasks.gym_registration as gym_registration
@@ -75,8 +75,8 @@ what `config.seed` reproduces. `reset()` without a seed touches no RNG.
 
 | Built via | `reset()` does |
 | --- | --- |
-| `configure=True` (gym) | Samples a **new** episode, except the first call, which uses the episode built during construction. Pass `seed` or `options` to force a re-sample. |
-| `sample_task()` (datagen) | Clears task state only; the scene and episode are untouched. A new episode means another `sample_task()`. |
+| `episode_source="self"` (gym) | Samples a **new** episode, except the first call, which uses the episode built during construction. Pass `seed` or `options` to force a re-sample. |
+| `episode_source="sampler"`, via `sample_task()` (datagen) | Clears task state only; the scene and episode are untouched. A new episode means another `sample_task()`. |
 
 `options` accepts only `house_index` and `force_advance_scene`; anything else
 raises.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Benchmark Evaluation: evaluation_guide.md
       - Evaluation Lifecycle: evaluation_lifecycle.md
       - Code Structure: code_structure.md
+      - Gym Compatibility: gym_compatibility.md
       - Development: development.md
       - Tutorials:
         - "Add a custom robot": tutorials/add_robot.md

--- a/mlspaces_tests/data_generation/test_gym_env_interface.py
+++ b/mlspaces_tests/data_generation/test_gym_env_interface.py
@@ -7,9 +7,11 @@ that path and pin the parts of the gymnasium contract that do hold; see
 """
 
 import gymnasium as gym
+import numpy as np
 import pytest
 
 from mlspaces_tests.data_generation.config import FrankaPickAndPlaceDroidTestConfig
+from molmo_spaces.tasks import gym_registration
 from molmo_spaces.tasks.task import BaseMujocoTask
 from molmo_spaces.tasks.task_sampler_errors import EpisodesExhausted
 
@@ -151,3 +153,54 @@ def test_reset_rejects_unknown_options(gym_config):
             task.reset(options={"not_a_real_option": 1})
     finally:
         task.close()
+
+
+def test_render_returns_an_rgb_frame(self_configured_task):
+    frame = self_configured_task.render()
+    assert frame.ndim == 3 and frame.shape[2] == 3
+    assert frame.dtype == np.uint8
+    assert "rgb_array" in type(self_configured_task).metadata["render_modes"]
+
+
+def test_render_rejects_unsupported_mode(gym_config):
+    task = gym_config.task_config.task_cls(
+        exp_config=gym_config, configure=True, render_mode="human"
+    )
+    try:
+        with pytest.raises(ValueError, match="Unsupported render_mode"):
+            task.render()
+    finally:
+        task.close()
+
+
+def test_spaces_are_deliberately_absent(self_configured_task):
+    """Pinned so the omission is a decision, not an accident. See docs/gym_compatibility.md."""
+    assert getattr(self_configured_task, "action_space", None) is None
+    assert getattr(self_configured_task, "observation_space", None) is None
+
+
+def test_make_env_builds_a_task_from_a_config_object(gym_config):
+    env = gym_registration.make_env(exp_config=gym_config)
+    try:
+        assert isinstance(env, gym.Env)
+        assert env._self_configured
+        assert env.get_task_description().strip()
+    finally:
+        env.close()
+
+
+def test_make_env_requires_exactly_one_source(gym_config):
+    with pytest.raises(ValueError, match="exactly one"):
+        gym_registration.make_env()
+    with pytest.raises(ValueError, match="exactly one"):
+        gym_registration.make_env(config_name="X", exp_config=gym_config)
+
+
+def test_register_configs_is_idempotent():
+    import molmo_spaces.data_generation.config.object_manipulation_datagen_configs  # noqa: F401
+
+    first = gym_registration.register_configs()
+    assert first, "expected at least one config to register"
+    assert all(env_id in gym.registry for env_id in first)
+    # A second call must not raise or re-register.
+    assert gym_registration.register_configs() == []

--- a/mlspaces_tests/data_generation/test_gym_env_interface.py
+++ b/mlspaces_tests/data_generation/test_gym_env_interface.py
@@ -1,0 +1,99 @@
+"""Tests for the gymnasium interface on tasks.
+
+A task can build itself -- creating its own sampler, having it prepare a scene
+and sample an episode -- instead of being built by a sampler. These tests cover
+that path and pin the parts of the gymnasium contract that do hold; see
+``docs/gym_compatibility.md`` for the parts that do not.
+"""
+
+import gymnasium as gym
+import pytest
+
+from mlspaces_tests.data_generation.config import FrankaPickAndPlaceDroidTestConfig
+from molmo_spaces.tasks.task import BaseMujocoTask
+from molmo_spaces.tasks.task_sampler_errors import EpisodesExhausted
+
+
+@pytest.fixture(scope="module")
+def gym_config():
+    config = FrankaPickAndPlaceDroidTestConfig()
+    config.use_passive_viewer = False
+    config.profile = False
+    config.use_wandb = False
+    return config
+
+
+@pytest.fixture(scope="module")
+def self_configured_task(gym_config):
+    """A task that sampled its own episode (the gymnasium entry point)."""
+    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    yield task
+    task.close()
+
+
+def test_task_is_a_gym_env(self_configured_task):
+    assert isinstance(self_configured_task, gym.Env)
+    # gym.Env's own initialization must have happened, not just ours.
+    assert self_configured_task.unwrapped is self_configured_task
+    assert self_configured_task.np_random is not None
+
+
+def test_self_configuration_produced_an_episode(self_configured_task):
+    task = self_configured_task
+    assert task._owns_sampler, "task should have created its own sampler"
+    assert task._env is task._sampler.env, "task must bind the sampler's current sim env"
+    assert task._env.n_batch == 1
+    assert task.get_task_description().strip()
+    # Step ratios are derived from the bound env's model, so they must be sane.
+    assert task._n_sim_steps_per_ctrl >= 1
+    assert task._n_ctrl_steps_per_policy >= 1
+
+
+def test_reset_returns_observation_and_info(self_configured_task):
+    observation, info = self_configured_task.reset()
+    assert len(observation) == 1
+    assert observation[0], "expected a non-empty observation dict"
+    assert len(info) == 1
+
+
+def test_sampler_path_and_gym_path_agree_on_observation_keys(gym_config, self_configured_task):
+    """Both construction paths must yield the same observation contract."""
+    sampler = gym_config.task_sampler_config.task_sampler_class(gym_config)
+    try:
+        sampler_task = sampler.sample_task()
+        assert isinstance(sampler_task, BaseMujocoTask)
+        sampler_obs, _ = sampler_task.reset()
+        gym_obs, _ = self_configured_task.reset()
+        assert set(sampler_obs[0]) == set(gym_obs[0])
+        sampler_task.close()
+    finally:
+        sampler.close()
+
+
+def test_batched_config_is_rejected_on_the_gym_path(gym_config, monkeypatch):
+    """The gymnasium interface is single-env only, and says so up front."""
+    task = None
+    try:
+        task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+        monkeypatch.setattr(type(task._env), "n_batch", property(lambda self: 2))
+        with pytest.raises(ValueError, match="single-environment only"):
+            gym_config.task_config.task_cls(
+                exp_config=gym_config, task_sampler=task._sampler, configure=True
+            )
+    finally:
+        if task is not None:
+            task.close()
+
+
+def test_exhausted_sampler_raises_rather_than_returning_none(gym_config):
+    """sample_task() returns None when out of tasks; the gym path must not."""
+    sampler = gym_config.task_sampler_config.task_sampler_class(gym_config)
+    try:
+        sampler._current_tasks_left = 0
+        assert sampler.sample_task() is None
+        with pytest.raises(EpisodesExhausted):
+            gym_config.task_config.task_cls(
+                exp_config=gym_config, task_sampler=sampler, configure=True
+            )
+    finally:
+        sampler.close()

--- a/mlspaces_tests/data_generation/test_gym_env_interface.py
+++ b/mlspaces_tests/data_generation/test_gym_env_interface.py
@@ -12,7 +12,7 @@ import pytest
 
 from mlspaces_tests.data_generation.config import FrankaPickAndPlaceDroidTestConfig
 from molmo_spaces.tasks import gym_registration
-from molmo_spaces.tasks.task import BaseMujocoTask
+from molmo_spaces.tasks.task import BaseMujocoTask, EpisodeSource
 from molmo_spaces.tasks.task_sampler_errors import EpisodesExhausted
 
 
@@ -28,7 +28,7 @@ def gym_config():
 @pytest.fixture(scope="module")
 def self_configured_task(gym_config):
     """A task that sampled its own episode (the gymnasium entry point)."""
-    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
     yield task
     task.close()
 
@@ -76,11 +76,11 @@ def test_batched_config_is_rejected_on_the_gym_path(gym_config, monkeypatch):
     """The gymnasium interface is single-env only, and says so up front."""
     task = None
     try:
-        task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+        task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
         monkeypatch.setattr(type(task._env), "n_batch", property(lambda self: 2))
         with pytest.raises(ValueError, match="single-environment only"):
             gym_config.task_config.task_cls(
-                exp_config=gym_config, task_sampler=task._sampler, configure=True
+                exp_config=gym_config, task_sampler=task._sampler, episode_source="self"
             )
     finally:
         if task is not None:
@@ -95,7 +95,7 @@ def test_exhausted_sampler_raises_rather_than_returning_none(gym_config):
         assert sampler.sample_task() is None
         with pytest.raises(EpisodesExhausted):
             gym_config.task_config.task_cls(
-                exp_config=gym_config, task_sampler=sampler, configure=True
+                exp_config=gym_config, task_sampler=sampler, episode_source="self"
             )
     finally:
         sampler.close()
@@ -103,7 +103,7 @@ def test_exhausted_sampler_raises_rather_than_returning_none(gym_config):
 
 def test_first_reset_keeps_the_episode_built_at_construction(gym_config):
     """__init__ already sampled an episode; the first reset must not throw it away."""
-    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
     try:
         description = task.get_task_description()
         task.reset()
@@ -114,7 +114,7 @@ def test_first_reset_keeps_the_episode_built_at_construction(gym_config):
 
 def test_later_resets_sample_a_new_episode(gym_config):
     """A self-configured task advances episodes on reset, as gym callers expect."""
-    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
     try:
         task.reset()
         first = task.get_task_description()
@@ -140,14 +140,14 @@ def test_sampler_built_task_reset_does_not_resample(gym_config):
         task.reset()
         task.reset()
         assert task.get_task_description() == description
-        assert not task._self_configured
+        assert task.episode_source is EpisodeSource.SAMPLER
         task.close()
     finally:
         sampler.close()
 
 
 def test_reset_rejects_unknown_options(gym_config):
-    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
     try:
         with pytest.raises(ValueError, match="Unsupported reset options"):
             task.reset(options={"not_a_real_option": 1})
@@ -164,7 +164,7 @@ def test_render_returns_an_rgb_frame(self_configured_task):
 
 def test_render_rejects_unsupported_mode(gym_config):
     task = gym_config.task_config.task_cls(
-        exp_config=gym_config, configure=True, render_mode="human"
+        exp_config=gym_config, episode_source="self", render_mode="human"
     )
     try:
         with pytest.raises(ValueError, match="Unsupported render_mode"):
@@ -183,7 +183,7 @@ def test_make_env_builds_a_task_from_a_config_object(gym_config):
     env = gym_registration.make_env(exp_config=gym_config)
     try:
         assert isinstance(env, gym.Env)
-        assert env._self_configured
+        assert env.episode_source is EpisodeSource.SELF
         assert env.get_task_description().strip()
     finally:
         env.close()

--- a/mlspaces_tests/data_generation/test_gym_env_interface.py
+++ b/mlspaces_tests/data_generation/test_gym_env_interface.py
@@ -28,7 +28,7 @@ def gym_config():
 @pytest.fixture(scope="module")
 def self_configured_task(gym_config):
     """A task that sampled its own episode (the gymnasium entry point)."""
-    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
+    task = gym_config.task_config.task_cls(exp_config=gym_config)
     yield task
     task.close()
 
@@ -76,12 +76,10 @@ def test_batched_config_is_rejected_on_the_gym_path(gym_config, monkeypatch):
     """The gymnasium interface is single-env only, and says so up front."""
     task = None
     try:
-        task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
+        task = gym_config.task_config.task_cls(exp_config=gym_config)
         monkeypatch.setattr(type(task._env), "n_batch", property(lambda self: 2))
         with pytest.raises(ValueError, match="single-environment only"):
-            gym_config.task_config.task_cls(
-                exp_config=gym_config, task_sampler=task._sampler, episode_source="self"
-            )
+            gym_config.task_config.task_cls(exp_config=gym_config, task_sampler=task._sampler)
     finally:
         if task is not None:
             task.close()
@@ -94,16 +92,18 @@ def test_exhausted_sampler_raises_rather_than_returning_none(gym_config):
         sampler._current_tasks_left = 0
         assert sampler.sample_task() is None
         with pytest.raises(EpisodesExhausted):
-            gym_config.task_config.task_cls(
-                exp_config=gym_config, task_sampler=sampler, episode_source="self"
-            )
+            gym_config.task_config.task_cls(exp_config=gym_config, task_sampler=sampler)
     finally:
         sampler.close()
 
 
 def test_first_reset_keeps_the_episode_built_at_construction(gym_config):
-    """__init__ already sampled an episode; the first reset must not throw it away."""
-    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
+    """__init__ already sampled an episode; the first reset must not throw it away.
+
+    Not just for speed: samplers consume their per-house candidate pool, so a
+    wasted episode brings the next HouseInvalidForTask closer.
+    """
+    task = gym_config.task_config.task_cls(exp_config=gym_config)
     try:
         description = task.get_task_description()
         task.reset()
@@ -112,10 +112,11 @@ def test_first_reset_keeps_the_episode_built_at_construction(gym_config):
         task.close()
 
 
-def test_later_resets_sample_a_new_episode(gym_config):
+def test_resets_keep_the_task_bound_to_the_live_env(gym_config):
     """A self-configured task advances episodes on reset, as gym callers expect."""
-    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
+    task = gym_config.task_config.task_cls(exp_config=gym_config)
     try:
+        assert task.episode_source is EpisodeSource.SELF, "derived from omitting env"
         task.reset()
         first = task.get_task_description()
         obs, info = task.reset()
@@ -146,13 +147,10 @@ def test_sampler_built_task_reset_does_not_resample(gym_config):
         sampler.close()
 
 
-def test_reset_rejects_unknown_options(gym_config):
-    task = gym_config.task_config.task_cls(exp_config=gym_config, episode_source="self")
-    try:
-        with pytest.raises(ValueError, match="Unsupported reset options"):
-            task.reset(options={"not_a_real_option": 1})
-    finally:
-        task.close()
+def test_reset_rejects_unknown_options(self_configured_task):
+    """Unknown options are prepare_episode's TypeError, not a hand-rolled check."""
+    with pytest.raises(TypeError, match="not_a_real_option"):
+        self_configured_task.reset(options={"not_a_real_option": 1})
 
 
 def test_render_returns_an_rgb_frame(self_configured_task):
@@ -162,15 +160,10 @@ def test_render_returns_an_rgb_frame(self_configured_task):
     assert "rgb_array" in type(self_configured_task).metadata["render_modes"]
 
 
-def test_render_rejects_unsupported_mode(gym_config):
-    task = gym_config.task_config.task_cls(
-        exp_config=gym_config, episode_source="self", render_mode="human"
-    )
-    try:
-        with pytest.raises(ValueError, match="Unsupported render_mode"):
-            task.render()
-    finally:
-        task.close()
+def test_render_rejects_unsupported_mode(self_configured_task, monkeypatch):
+    monkeypatch.setattr(self_configured_task, "render_mode", "human")
+    with pytest.raises(ValueError, match="Unsupported render_mode"):
+        self_configured_task.render()
 
 
 def test_spaces_are_deliberately_absent(self_configured_task):

--- a/mlspaces_tests/data_generation/test_gym_env_interface.py
+++ b/mlspaces_tests/data_generation/test_gym_env_interface.py
@@ -97,3 +97,57 @@ def test_exhausted_sampler_raises_rather_than_returning_none(gym_config):
             )
     finally:
         sampler.close()
+
+
+def test_first_reset_keeps_the_episode_built_at_construction(gym_config):
+    """__init__ already sampled an episode; the first reset must not throw it away."""
+    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    try:
+        description = task.get_task_description()
+        task.reset()
+        assert task.get_task_description() == description
+    finally:
+        task.close()
+
+
+def test_later_resets_sample_a_new_episode(gym_config):
+    """A self-configured task advances episodes on reset, as gym callers expect."""
+    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    try:
+        task.reset()
+        first = task.get_task_description()
+        obs, info = task.reset()
+        assert obs[0], "expected observations for the new episode"
+        assert task.episode_step_count == 0
+        assert not task.observation_cache[1:], "caches must be cleared for the new episode"
+        # The sampler advanced, so task state was rebuilt; the description may or
+        # may not differ (same house can resample the same objects), but the env
+        # binding must always be the sampler's current one.
+        assert task._env is task._sampler.env
+        assert isinstance(first, str)
+    finally:
+        task.close()
+
+
+def test_sampler_built_task_reset_does_not_resample(gym_config):
+    """The data generation path keeps its reset semantics: clear state, same episode."""
+    sampler = gym_config.task_sampler_config.task_sampler_class(gym_config)
+    try:
+        task = sampler.sample_task()
+        description = task.get_task_description()
+        task.reset()
+        task.reset()
+        assert task.get_task_description() == description
+        assert not task._self_configured
+        task.close()
+    finally:
+        sampler.close()
+
+
+def test_reset_rejects_unknown_options(gym_config):
+    task = gym_config.task_config.task_cls(exp_config=gym_config, configure=True)
+    try:
+        with pytest.raises(ValueError, match="Unsupported reset options"):
+            task.reset(options={"not_a_real_option": 1})
+    finally:
+        task.close()

--- a/molmo_spaces/tasks/eval_task_sampler.py
+++ b/molmo_spaces/tasks/eval_task_sampler.py
@@ -13,7 +13,6 @@ from molmo_spaces.env.data_views import (
 )
 from molmo_spaces.env.env import CPUMujocoEnv
 from molmo_spaces.molmo_spaces_constants import ASSETS_DIR
-from molmo_spaces.tasks.pick_task import PickTask
 from molmo_spaces.tasks.pick_task_sampler import PickTaskSampler
 from molmo_spaces.utils.constants.object_constants import (
     THOR_PICKUP_OBJECTS_LOWERCASE,
@@ -202,8 +201,12 @@ class EvalTaskSampler(PickTaskSampler):
 
         log.info("Scene setup completed.\n")
 
-    def _sample_task(self, env: CPUMujocoEnv) -> PickTask:
-        """Sample a pick-and-place task configuration and create the task."""
+    @property
+    def task_class(self):
+        return self.config.task_config.task_cls
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+        """Sample a pick-and-place task configuration."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -228,9 +231,6 @@ class EvalTaskSampler(PickTaskSampler):
         # Setup cameras after pickup object and robot placement
         # This allows cameras to use task-specific info (pickup object, workspace center)
         self.setup_cameras(env)
-
-        task = self.config.task_config.task_cls(env, self.config)
-        return task
 
     def _sample_and_place_robot(self, env: CPUMujocoEnv) -> None:
         """Sample a pickup object and receptacle, place robot using occupancy map, and return sampled params.
@@ -290,8 +290,12 @@ class DefaulEvalTaskSampler(BaseMujocoTaskSampler):
     def add_auxiliary_objects(self, spec: MjSpec) -> None:
         return
 
-    def _sample_task(self, env: CPUMujocoEnv) -> PickTask:
-        """Sample a pick-and-place task configuration and create the task."""
+    @property
+    def task_class(self):
+        return self.config.task_config.task_cls
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+        """Sample a pick-and-place task configuration."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -310,9 +314,6 @@ class DefaulEvalTaskSampler(BaseMujocoTaskSampler):
         # Setup cameras after pickup object and robot placement
         # This allows cameras to use task-specific info (pickup object, workspace center)
         self.setup_cameras(env)
-
-        task = self.config.task_config.task_cls(env, self.config)
-        return task
 
     def _sample_and_place_robot(self, env: CPUMujocoEnv) -> None:
         task_cfg = self.config.task_config

--- a/molmo_spaces/tasks/eval_task_sampler.py
+++ b/molmo_spaces/tasks/eval_task_sampler.py
@@ -13,6 +13,7 @@ from molmo_spaces.env.data_views import (
 )
 from molmo_spaces.env.env import CPUMujocoEnv
 from molmo_spaces.molmo_spaces_constants import ASSETS_DIR
+from molmo_spaces.tasks.pick_task import PickTask
 from molmo_spaces.tasks.pick_task_sampler import PickTaskSampler
 from molmo_spaces.utils.constants.object_constants import (
     THOR_PICKUP_OBJECTS_LOWERCASE,
@@ -201,12 +202,8 @@ class EvalTaskSampler(PickTaskSampler):
 
         log.info("Scene setup completed.\n")
 
-    @property
-    def task_class(self):
-        return self.config.task_config.task_cls
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
-        """Sample a pick-and-place task configuration."""
+    def _sample_task(self, env: CPUMujocoEnv, task: PickTask | None = None) -> PickTask:
+        """Sample a pick-and-place task configuration and create the task."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -231,6 +228,10 @@ class EvalTaskSampler(PickTaskSampler):
         # Setup cameras after pickup object and robot placement
         # This allows cameras to use task-specific info (pickup object, workspace center)
         self.setup_cameras(env)
+
+        if task is None:
+            task = self.config.task_config.task_cls(env, self.config)
+        return task
 
     def _sample_and_place_robot(self, env: CPUMujocoEnv) -> None:
         """Sample a pickup object and receptacle, place robot using occupancy map, and return sampled params.
@@ -290,12 +291,8 @@ class DefaulEvalTaskSampler(BaseMujocoTaskSampler):
     def add_auxiliary_objects(self, spec: MjSpec) -> None:
         return
 
-    @property
-    def task_class(self):
-        return self.config.task_config.task_cls
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
-        """Sample a pick-and-place task configuration."""
+    def _sample_task(self, env: CPUMujocoEnv, task: PickTask | None = None) -> PickTask:
+        """Sample a pick-and-place task configuration and create the task."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -314,6 +311,10 @@ class DefaulEvalTaskSampler(BaseMujocoTaskSampler):
         # Setup cameras after pickup object and robot placement
         # This allows cameras to use task-specific info (pickup object, workspace center)
         self.setup_cameras(env)
+
+        if task is None:
+            task = self.config.task_config.task_cls(env, self.config)
+        return task
 
     def _sample_and_place_robot(self, env: CPUMujocoEnv) -> None:
         task_cfg = self.config.task_config

--- a/molmo_spaces/tasks/gym_registration.py
+++ b/molmo_spaces/tasks/gym_registration.py
@@ -25,7 +25,7 @@ from molmo_spaces.data_generation.config_registry import (
     get_config_class,
     list_available_configs,
 )
-from molmo_spaces.tasks.task import BaseMujocoTask
+from molmo_spaces.tasks.task import BaseMujocoTask, EpisodeSource
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ def make_env(
             f"so there is no task class to build."
         )
 
-    return task_cls(exp_config=exp_config, configure=True, **task_kwargs)
+    return task_cls(exp_config=exp_config, episode_source=EpisodeSource.SELF, **task_kwargs)
 
 
 def register_configs(version: int = 0) -> list[str]:

--- a/molmo_spaces/tasks/gym_registration.py
+++ b/molmo_spaces/tasks/gym_registration.py
@@ -25,7 +25,7 @@ from molmo_spaces.data_generation.config_registry import (
     get_config_class,
     list_available_configs,
 )
-from molmo_spaces.tasks.task import BaseMujocoTask, EpisodeSource
+from molmo_spaces.tasks.task import BaseMujocoTask
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +74,8 @@ def make_env(
             f"so there is no task class to build."
         )
 
-    return task_cls(exp_config=exp_config, episode_source=EpisodeSource.SELF, **task_kwargs)
+    # No env, so the task samples its own episode (EpisodeSource.SELF).
+    return task_cls(exp_config=exp_config, **task_kwargs)
 
 
 def register_configs(version: int = 0) -> list[str]:

--- a/molmo_spaces/tasks/gym_registration.py
+++ b/molmo_spaces/tasks/gym_registration.py
@@ -1,0 +1,107 @@
+"""Gymnasium registration for molmospaces tasks.
+
+Tasks are gymnasium envs (see :mod:`molmo_spaces.tasks.task`), so they can be
+built through ``gymnasium.make`` once registered:
+
+    import molmo_spaces.tasks.gym_registration as reg
+    reg.register_configs()
+    env = gymnasium.make("MolmoSpaces/FrankaPickAndPlace-v0")
+
+Env ids come from the data generation config registry, so anything registered
+with ``@register_config`` is available here under the same name.
+
+Read ``docs/gym_compatibility.md`` before using these envs with third-party RL
+code: they declare neither ``action_space`` nor ``observation_space``, so
+``gymnasium.utils.env_checker.check_env`` and most wrappers will not work.
+"""
+
+import logging
+from typing import Any
+
+import gymnasium as gym
+
+from molmo_spaces.configs.abstract_exp_config import MlSpacesExpConfig
+from molmo_spaces.data_generation.config_registry import (
+    get_config_class,
+    list_available_configs,
+)
+from molmo_spaces.tasks.task import BaseMujocoTask
+
+log = logging.getLogger(__name__)
+
+NAMESPACE = "MolmoSpaces"
+
+
+def env_id_for_config(config_name: str, version: int = 0) -> str:
+    """The gymnasium env id for a registered config name."""
+    return f"{NAMESPACE}/{config_name}-v{version}"
+
+
+def make_env(
+    config_name: str | None = None,
+    exp_config: MlSpacesExpConfig | None = None,
+    *,
+    config_overrides: dict[str, Any] | None = None,
+    **task_kwargs: Any,
+) -> BaseMujocoTask:
+    """Build a task as a gymnasium env, sampling its own episode.
+
+    Args:
+        config_name: Name of a config in the data generation config registry.
+        exp_config: An already-built config, instead of ``config_name``.
+        config_overrides: Attributes to set on the config before sampling.
+        **task_kwargs: Forwarded to the task (e.g. ``render_mode``,
+            ``task_sampler``, ``episode_options``).
+
+    Returns:
+        A task bound to a freshly sampled episode.
+    """
+    if (config_name is None) == (exp_config is None):
+        raise ValueError("Pass exactly one of config_name or exp_config")
+
+    if exp_config is None:
+        exp_config = get_config_class(config_name)()
+
+    for key, value in (config_overrides or {}).items():
+        if not hasattr(exp_config, key):
+            raise ValueError(f"Config {type(exp_config).__name__} has no attribute {key!r}")
+        setattr(exp_config, key, value)
+
+    task_cls = exp_config.task_config.task_cls
+    if task_cls is None:
+        raise ValueError(
+            f"Config {type(exp_config).__name__} has no task_config.task_cls, "
+            f"so there is no task class to build."
+        )
+
+    return task_cls(exp_config=exp_config, configure=True, **task_kwargs)
+
+
+def register_configs(version: int = 0) -> list[str]:
+    """Register every config in the config registry as a gymnasium env.
+
+    Idempotent: ids already present in the gymnasium registry are skipped, so
+    calling this more than once (or after a partial registration) is safe.
+
+    Returns:
+        The env ids registered by this call.
+    """
+    registered = []
+    for config_name in list_available_configs():
+        env_id = env_id_for_config(config_name, version=version)
+        if env_id in gym.registry:
+            continue
+        gym.register(
+            id=env_id,
+            entry_point="molmo_spaces.tasks.gym_registration:make_env",
+            kwargs={"config_name": config_name},
+            # Task horizon is enforced by the task itself (is_timed_out), and
+            # letting gym also wrap it would truncate twice.
+            max_episode_steps=None,
+            # These envs cannot pass gym's checker (no spaces declared).
+            disable_env_checker=True,
+        )
+        registered.append(env_id)
+
+    log.info(f"Registered {len(registered)} molmospaces envs with gymnasium")
+    return registered

--- a/molmo_spaces/tasks/json_eval_task_sampler.py
+++ b/molmo_spaces/tasks/json_eval_task_sampler.py
@@ -837,9 +837,7 @@ class JsonEvalTaskSampler(BaseMujocoTaskSampler):
         # Replace the stub task_config with the properly typed one
         self.config.task_config = task_config
 
-    def _sample_task(
-        self, env: CPUMujocoEnv, task: BaseMujocoTask | None = None
-    ) -> BaseMujocoTask:
+    def _sample_task(self, env: CPUMujocoEnv, task: BaseMujocoTask | None = None) -> BaseMujocoTask:
         """
         Create the task from episode spec.
 

--- a/molmo_spaces/tasks/json_eval_task_sampler.py
+++ b/molmo_spaces/tasks/json_eval_task_sampler.py
@@ -837,12 +837,26 @@ class JsonEvalTaskSampler(BaseMujocoTaskSampler):
         # Replace the stub task_config with the properly typed one
         self.config.task_config = task_config
 
-    def _sample_task(self, env: CPUMujocoEnv) -> BaseMujocoTask:
-        """
-        Create the task from episode spec.
+    @property
+    def task_class(self) -> type:
+        return self._get_task_class()
 
-        Unlike other task samplers, this doesn't sample - it creates the task
-        using the exact configuration from the episode spec.
+    def _post_construct(self, task: BaseMujocoTask) -> None:
+        # The benchmark's recorded description wins over whatever the task class
+        # would derive from the config.
+        task_description = self.episode_spec.language.task_description
+
+        def get_task_description(self, _td=task_description) -> str:
+            return _td
+
+        task.get_task_description = types.MethodType(get_task_description, task)
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+        """
+        Configure the episode from the episode spec.
+
+        Unlike other task samplers, this doesn't sample - it applies the exact
+        configuration from the episode spec.
         """
         assert env.current_batch_index == 0
 
@@ -878,16 +892,3 @@ class JsonEvalTaskSampler(BaseMujocoTaskSampler):
 
         # only one camera setup is needed. cameras and robot placement are not randomized.
         self.setup_cameras(env)
-
-        # Get task class and instantiate
-        task_cls = self._get_task_class()
-        task = task_cls(env, self.config)
-
-        task_description = self.episode_spec.language.task_description
-
-        def get_task_description(self, _td=task_description) -> str:
-            return _td
-
-        task.get_task_description = types.MethodType(get_task_description, task)
-
-        return task

--- a/molmo_spaces/tasks/json_eval_task_sampler.py
+++ b/molmo_spaces/tasks/json_eval_task_sampler.py
@@ -837,26 +837,14 @@ class JsonEvalTaskSampler(BaseMujocoTaskSampler):
         # Replace the stub task_config with the properly typed one
         self.config.task_config = task_config
 
-    @property
-    def task_class(self) -> type:
-        return self._get_task_class()
-
-    def _post_construct(self, task: BaseMujocoTask) -> None:
-        # The benchmark's recorded description wins over whatever the task class
-        # would derive from the config.
-        task_description = self.episode_spec.language.task_description
-
-        def get_task_description(self, _td=task_description) -> str:
-            return _td
-
-        task.get_task_description = types.MethodType(get_task_description, task)
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+    def _sample_task(
+        self, env: CPUMujocoEnv, task: BaseMujocoTask | None = None
+    ) -> BaseMujocoTask:
         """
-        Configure the episode from the episode spec.
+        Create the task from episode spec.
 
-        Unlike other task samplers, this doesn't sample - it applies the exact
-        configuration from the episode spec.
+        Unlike other task samplers, this doesn't sample - it creates the task
+        using the exact configuration from the episode spec.
         """
         assert env.current_batch_index == 0
 
@@ -892,3 +880,16 @@ class JsonEvalTaskSampler(BaseMujocoTaskSampler):
 
         # only one camera setup is needed. cameras and robot placement are not randomized.
         self.setup_cameras(env)
+
+        # Get task class and instantiate
+        if task is None:
+            task = self._get_task_class()(env, self.config)
+
+        task_description = self.episode_spec.language.task_description
+
+        def get_task_description(self, _td=task_description) -> str:
+            return _td
+
+        task.get_task_description = types.MethodType(get_task_description, task)
+
+        return task

--- a/molmo_spaces/tasks/multi_task.py
+++ b/molmo_spaces/tasks/multi_task.py
@@ -87,10 +87,10 @@ class MultiTask(BaseMujocoTask):
         obs_scene["num_tasks"] = len(self.tasks)
         return obs_scene
 
-    def reset(self) -> dict[str, Any]:
+    def reset(self, **kwargs: Any) -> dict[str, Any]:
         for task in self.tasks:
-            task.reset()
-        return self.tasks[0].reset()
+            task.reset(**kwargs)
+        return self.tasks[0].reset(**kwargs)
 
     def step(
         self, action: dict[str, Any]

--- a/molmo_spaces/tasks/multi_task.py
+++ b/molmo_spaces/tasks/multi_task.py
@@ -12,34 +12,19 @@ class MultiTask(BaseMujocoTask):
         if not tasks:
             raise ValueError("MultiTask requires at least one task")
 
+        # Defer to the base for all the standard task state (counters, caches,
+        # timing, sensor suite) so MultiTask picks up anything the base adds
+        # rather than re-deriving it field by field.
+        super().__init__(tasks[0]._env, tasks[0].config)
+
         self.tasks = tasks
         self.prompt = prompt
 
         self.max_rewards = [0.0] * len(tasks)
 
-        self._env = tasks[0]._env
-        self._ctrl_dt_ms = tasks[0]._ctrl_dt_ms
-        self._n_sim_steps_per_ctrl = tasks[0]._n_sim_steps_per_ctrl
-        self._n_ctrl_steps_per_policy = tasks[0]._n_ctrl_steps_per_policy
-        self._task_horizon = tasks[0]._task_horizon
-        self._cumulative_reward = np.zeros(self._env.n_batch)
-        self._num_steps_taken = np.zeros(self._env.n_batch, dtype=int)
-        self.config = tasks[0].config
-        self.episode_step_count = 0
-        self.viewer = None
-        self.frozen_config = None
+        # Share the first task's sensor suite instead of the one the base built,
+        # so sub-task sensors and MultiTask's observations stay consistent.
         self._sensor_suite = tasks[0]._sensor_suite
-        self.last_action = None
-        self.action_cache = []
-        self.observation_cache = []
-        self.reward_cache = []
-        self.terminal_cache = []
-        self.truncated_cache = []
-        self.success_cache = []
-        self._policy_done = False
-        self._registered_policy = None
-        self._done_action_received = False
-        self._datagen_profiler = None
 
     def _create_sensor_suite_from_config(self, exp_config):
         return SensorSuite(get_core_sensors(exp_config))

--- a/molmo_spaces/tasks/nav_task.py
+++ b/molmo_spaces/tasks/nav_task.py
@@ -16,11 +16,13 @@ class NavToObjTask(BaseMujocoTask):
     """Navigation to object task implementation."""
 
     def __init__(self, env: BaseMujocoEnv, exp_config: MlSpacesExpConfig) -> None:
-        super().__init__(env, exp_config)
+        # Set before super().__init__, which runs _on_episode_configured().
         self.exp_config = exp_config
+        super().__init__(env, exp_config)
 
+    def _on_episode_configured(self) -> None:
         # For eval mode: reconstruct candidate list from category if needed
-        self._reconstruct_candidate_list_if_needed(env)
+        self._reconstruct_candidate_list_if_needed(self._env)
 
         self.nav_objs = self._get_nav_objects()
 

--- a/molmo_spaces/tasks/nav_task_sampler.py
+++ b/molmo_spaces/tasks/nav_task_sampler.py
@@ -137,9 +137,7 @@ class NavToObjTaskSampler(BaseMujocoTaskSampler):
         # Delegate to base class for other keys (e.g., __gripper__)
         return super().resolve_visibility_object(env, key)
 
-    def _sample_task(
-        self, env: CPUMujocoEnv, task: NavToObjTask | None = None
-    ) -> NavToObjTask:
+    def _sample_task(self, env: CPUMujocoEnv, task: NavToObjTask | None = None) -> NavToObjTask:
         """Sample a navigation to object task configuration and create the task."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly

--- a/molmo_spaces/tasks/nav_task_sampler.py
+++ b/molmo_spaces/tasks/nav_task_sampler.py
@@ -137,8 +137,14 @@ class NavToObjTaskSampler(BaseMujocoTaskSampler):
         # Delegate to base class for other keys (e.g., __gripper__)
         return super().resolve_visibility_object(env, key)
 
-    def _sample_task(self, env: CPUMujocoEnv) -> NavToObjTask:
-        """Sample a navigation to object task configuration and create the task."""
+    task_cls = NavToObjTask
+
+    def _post_construct(self, task: NavToObjTask) -> None:
+        # Store occupancy map reference in task for policy access
+        task.occupancy_map = self._cached_thormap
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+        """Sample a navigation to object task configuration."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -282,11 +288,6 @@ class NavToObjTaskSampler(BaseMujocoTaskSampler):
         self.config.task_config.referral_expressions_priority["object_name"] = [
             (1.0, 1.0, object_name)
         ]
-
-        task: NavToObjTask = NavToObjTask(env, exp_config=self.config)
-        # Store occupancy map reference in task for policy access
-        task.occupancy_map = self._cached_thormap
-        return task
 
     def _get_scene_objects(self, env: CPUMujocoEnv) -> list[MlSpacesObject]:
         """

--- a/molmo_spaces/tasks/nav_task_sampler.py
+++ b/molmo_spaces/tasks/nav_task_sampler.py
@@ -137,14 +137,10 @@ class NavToObjTaskSampler(BaseMujocoTaskSampler):
         # Delegate to base class for other keys (e.g., __gripper__)
         return super().resolve_visibility_object(env, key)
 
-    task_cls = NavToObjTask
-
-    def _post_construct(self, task: NavToObjTask) -> None:
-        # Store occupancy map reference in task for policy access
-        task.occupancy_map = self._cached_thormap
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
-        """Sample a navigation to object task configuration."""
+    def _sample_task(
+        self, env: CPUMujocoEnv, task: NavToObjTask | None = None
+    ) -> NavToObjTask:
+        """Sample a navigation to object task configuration and create the task."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -288,6 +284,12 @@ class NavToObjTaskSampler(BaseMujocoTaskSampler):
         self.config.task_config.referral_expressions_priority["object_name"] = [
             (1.0, 1.0, object_name)
         ]
+
+        if task is None:
+            task = NavToObjTask(env, exp_config=self.config)
+        # Store occupancy map reference in task for policy access
+        task.occupancy_map = self._cached_thormap
+        return task
 
     def _get_scene_objects(self, env: CPUMujocoEnv) -> list[MlSpacesObject]:
         """

--- a/molmo_spaces/tasks/opening_task_samplers.py
+++ b/molmo_spaces/tasks/opening_task_samplers.py
@@ -52,10 +52,13 @@ class OpenTaskSampler(PickTaskSampler):
         log.info(f"Skipping {pickup_obj.name} (uid={asset_uid}) - no grasp file available")
         return False
 
-    task_cls = OpeningTask
-
-    def _configure_episode(self, env: CPUMujocoEnv, skip_robot_placement: bool = False) -> None:
-        """Sample an opening or closing task configuration."""
+    def _sample_task(
+        self,
+        env: CPUMujocoEnv,
+        task: OpeningTask | None = None,
+        skip_robot_placement: bool = False,
+    ) -> OpeningTask:
+        """Sample an opening or closing task configuration and create the task."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -117,6 +120,10 @@ class OpenTaskSampler(PickTaskSampler):
         # Setup cameras after pickup object and robot placement
         # This allows cameras to use task-specific info (pickup object, workspace center)
         self.setup_cameras(env)
+
+        if task is None:
+            task = OpeningTask(env, self.config)
+        return task
 
     def _sample_and_place_robot(self, env: CPUMujocoEnv) -> None:
         """Sample a pickup object and open/close the joint, place robot using occupancy map, and return sampled params.
@@ -456,12 +463,8 @@ class DoorOpeningTaskSampler(BaseMujocoTaskSampler):
             "Was not able to place robot near any door in the scene. Skipping this task."
         )
 
-    @property
-    def task_class(self):
-        return self.config.task_config.task_cls
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
-        """Sample a door opening task configuration."""
+    def _sample_task(self, env: CPUMujocoEnv, task: OpeningTask | None = None):
+        """Sample a door opening task configuration and create the task."""
 
         # Set current batch index to 0 (most common case for single-batch environments)
         env.current_batch_index = 0
@@ -515,3 +518,8 @@ class DoorOpeningTaskSampler(BaseMujocoTaskSampler):
         # All cameras are defined in camera_config (MJCF cameras for RBY1)
         # Dynamic cameras will be positioned based on get_workspace_center()
         self.setup_cameras(env)
+
+        # Create and return the task using self.config (which has the modified task_config)
+        if task is None:
+            task = task_cfg.task_cls(env, self.config)
+        return task

--- a/molmo_spaces/tasks/opening_task_samplers.py
+++ b/molmo_spaces/tasks/opening_task_samplers.py
@@ -52,8 +52,10 @@ class OpenTaskSampler(PickTaskSampler):
         log.info(f"Skipping {pickup_obj.name} (uid={asset_uid}) - no grasp file available")
         return False
 
-    def _sample_task(self, env: CPUMujocoEnv, skip_robot_placement: bool = False) -> OpeningTask:
-        """Sample an opening or closing task configuration and create the task."""
+    task_cls = OpeningTask
+
+    def _configure_episode(self, env: CPUMujocoEnv, skip_robot_placement: bool = False) -> None:
+        """Sample an opening or closing task configuration."""
         # Set current batch index to 0 (most common case for single-batch environments)
         # TODO(rose) at some point: handle multi-batch environments properly
         assert env.current_batch_index == 0
@@ -115,9 +117,6 @@ class OpenTaskSampler(PickTaskSampler):
         # Setup cameras after pickup object and robot placement
         # This allows cameras to use task-specific info (pickup object, workspace center)
         self.setup_cameras(env)
-
-        task = OpeningTask(env, self.config)
-        return task
 
     def _sample_and_place_robot(self, env: CPUMujocoEnv) -> None:
         """Sample a pickup object and open/close the joint, place robot using occupancy map, and return sampled params.
@@ -457,8 +456,12 @@ class DoorOpeningTaskSampler(BaseMujocoTaskSampler):
             "Was not able to place robot near any door in the scene. Skipping this task."
         )
 
-    def _sample_task(self, env: CPUMujocoEnv):
-        """Sample a door opening task configuration and create the task."""
+    @property
+    def task_class(self):
+        return self.config.task_config.task_cls
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+        """Sample a door opening task configuration."""
 
         # Set current batch index to 0 (most common case for single-batch environments)
         env.current_batch_index = 0
@@ -512,6 +515,3 @@ class DoorOpeningTaskSampler(BaseMujocoTaskSampler):
         # All cameras are defined in camera_config (MJCF cameras for RBY1)
         # Dynamic cameras will be positioned based on get_workspace_center()
         self.setup_cameras(env)
-
-        # Create and return the task using self.config (which has the modified task_config)
-        return task_cfg.task_cls(env, self.config)

--- a/molmo_spaces/tasks/packing_task_sampler.py
+++ b/molmo_spaces/tasks/packing_task_sampler.py
@@ -23,8 +23,6 @@ DEFAULT_BOX_UIDS = [f"Box_{i}" for i in range(1, 31)]
 
 
 class PackingTaskSampler(PickAndPlaceTaskSampler):
-    task_cls = PackingTask
-
     def __init__(self, config: "PackingDataGenConfig") -> None:
         assert config.task_type == "packing"
         super().__init__(config)
@@ -123,10 +121,10 @@ class PackingTaskSampler(PickAndPlaceTaskSampler):
 
         mujoco.mj_forward(model, data)
 
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+    def _sample_task(self, env: CPUMujocoEnv, task: PackingTask | None = None) -> PackingTask:
         """Sample a packing task — open box flaps, then delegate placement to parent."""
         # First let parent handle all placement (box, robot, cameras)
-        super()._configure_episode(env)
+        _ = super()._sample_task(env, task=task)
 
         # Open flaps AFTER placement so nothing can overwrite the qpos values
         self._open_box_flaps(env)
@@ -138,3 +136,7 @@ class PackingTaskSampler(PickAndPlaceTaskSampler):
             jnt_name = model.joint(i).name
             if namespace in jnt_name and "flap" in jnt_name:
                 log.info(f"VERIFY '{jnt_name}': qpos={data.qpos[model.jnt_qposadr[i]]:.3f}")
+
+        if task is None:
+            task = PackingTask(env, self.config)
+        return task

--- a/molmo_spaces/tasks/packing_task_sampler.py
+++ b/molmo_spaces/tasks/packing_task_sampler.py
@@ -23,6 +23,8 @@ DEFAULT_BOX_UIDS = [f"Box_{i}" for i in range(1, 31)]
 
 
 class PackingTaskSampler(PickAndPlaceTaskSampler):
+    task_cls = PackingTask
+
     def __init__(self, config: "PackingDataGenConfig") -> None:
         assert config.task_type == "packing"
         super().__init__(config)
@@ -121,10 +123,10 @@ class PackingTaskSampler(PickAndPlaceTaskSampler):
 
         mujoco.mj_forward(model, data)
 
-    def _sample_task(self, env: CPUMujocoEnv) -> PackingTask:
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
         """Sample a packing task — open box flaps, then delegate placement to parent."""
         # First let parent handle all placement (box, robot, cameras)
-        _ = super()._sample_task(env)
+        super()._configure_episode(env)
 
         # Open flaps AFTER placement so nothing can overwrite the qpos values
         self._open_box_flaps(env)
@@ -136,5 +138,3 @@ class PackingTaskSampler(PickAndPlaceTaskSampler):
             jnt_name = model.joint(i).name
             if namespace in jnt_name and "flap" in jnt_name:
                 log.info(f"VERIFY '{jnt_name}': qpos={data.qpos[model.jnt_qposadr[i]]:.3f}")
-
-        return PackingTask(env, self.config)

--- a/molmo_spaces/tasks/pick_and_place_color_task_sampler.py
+++ b/molmo_spaces/tasks/pick_and_place_color_task_sampler.py
@@ -138,12 +138,11 @@ class PickAndPlaceColorTaskSampler(PickAndPlaceReceptacleTaskSampler):
 
         return target_color_name, target_color_rgba
 
-    @property
-    def task_class(self):
+    def _sample_task(self, env: CPUMujocoEnv, task=None):
         from molmo_spaces.tasks.pick_and_place_color_task import PickAndPlaceColorTask
 
-        return PickAndPlaceColorTask
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
         self._configure_pick_and_place(env)
         self._assign_colors_to_receptacles(env)
+        if task is None:
+            task = PickAndPlaceColorTask(env, self.config)
+        return task

--- a/molmo_spaces/tasks/pick_and_place_color_task_sampler.py
+++ b/molmo_spaces/tasks/pick_and_place_color_task_sampler.py
@@ -138,9 +138,12 @@ class PickAndPlaceColorTaskSampler(PickAndPlaceReceptacleTaskSampler):
 
         return target_color_name, target_color_rgba
 
-    def _sample_task(self, env: CPUMujocoEnv):
+    @property
+    def task_class(self):
         from molmo_spaces.tasks.pick_and_place_color_task import PickAndPlaceColorTask
 
+        return PickAndPlaceColorTask
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
         self._configure_pick_and_place(env)
         self._assign_colors_to_receptacles(env)
-        return PickAndPlaceColorTask(env, self.config)

--- a/molmo_spaces/tasks/pick_and_place_next_to_task.py
+++ b/molmo_spaces/tasks/pick_and_place_next_to_task.py
@@ -42,9 +42,9 @@ class PickAndPlaceNextToTask(PickAndPlaceTask):
         place_name = self.config.task_config.referral_expressions["place_name"]
         return f"Pick up the {pickup_name} and place it next to the {place_name}"
 
-    def reset(self):
+    def reset(self, **kwargs):
         """Reset the task and print goal."""
-        observation, info = super().reset()
+        observation, info = super().reset(**kwargs)
 
         pickup_name = self.config.task_config.referral_expressions["pickup_name"]
         place_name = self.config.task_config.referral_expressions["place_name"]

--- a/molmo_spaces/tasks/pick_and_place_next_to_task_sampler.py
+++ b/molmo_spaces/tasks/pick_and_place_next_to_task_sampler.py
@@ -21,6 +21,8 @@ log = logging.getLogger(__name__)
 
 
 class PickAndPlaceNextToTaskSampler(AbstractPickAndPlaceObjectTargetTaskSampler):
+    task_cls = PickAndPlaceNextToTask
+
     def __init__(self, config: "PickAndPlaceNextToDataGenConfig") -> None:
         super().__init__(config)
         self.config: PickAndPlaceNextToDataGenConfig
@@ -166,6 +168,5 @@ class PickAndPlaceNextToTaskSampler(AbstractPickAndPlaceObjectTargetTaskSampler)
 
         return False
 
-    def _sample_task(self, env: CPUMujocoEnv) -> PickAndPlaceNextToTask:
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
         self._configure_pick_and_place(env)
-        return PickAndPlaceNextToTask(env, self.config)

--- a/molmo_spaces/tasks/pick_and_place_next_to_task_sampler.py
+++ b/molmo_spaces/tasks/pick_and_place_next_to_task_sampler.py
@@ -21,8 +21,6 @@ log = logging.getLogger(__name__)
 
 
 class PickAndPlaceNextToTaskSampler(AbstractPickAndPlaceObjectTargetTaskSampler):
-    task_cls = PickAndPlaceNextToTask
-
     def __init__(self, config: "PickAndPlaceNextToDataGenConfig") -> None:
         super().__init__(config)
         self.config: PickAndPlaceNextToDataGenConfig
@@ -168,5 +166,10 @@ class PickAndPlaceNextToTaskSampler(AbstractPickAndPlaceObjectTargetTaskSampler)
 
         return False
 
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+    def _sample_task(
+        self, env: CPUMujocoEnv, task: PickAndPlaceNextToTask | None = None
+    ) -> PickAndPlaceNextToTask:
         self._configure_pick_and_place(env)
+        if task is None:
+            task = PickAndPlaceNextToTask(env, self.config)
+        return task

--- a/molmo_spaces/tasks/pick_and_place_task.py
+++ b/molmo_spaces/tasks/pick_and_place_task.py
@@ -65,8 +65,8 @@ class PickAndPlaceTask(BaseMujocoTask):
 
         return SensorSuite(sensors)
 
-    def reset(self):
-        result = super().reset()
+    def reset(self, **kwargs: Any):
+        result = super().reset(**kwargs)
         self._supported_rel_poses.clear()
         return result
 

--- a/molmo_spaces/tasks/pick_and_place_task.py
+++ b/molmo_spaces/tasks/pick_and_place_task.py
@@ -21,8 +21,7 @@ from molmo_spaces.utils.pose import pos_quat_to_pose_mat
 class PickAndPlaceTask(BaseMujocoTask):
     """Franka pick-and-place task implementation."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def _on_episode_configured(self) -> None:
         self._supported_rel_poses: dict[int, list[np.ndarray]] = {}
 
     def get_task_description(self) -> str:

--- a/molmo_spaces/tasks/pick_and_place_task_sampler.py
+++ b/molmo_spaces/tasks/pick_and_place_task_sampler.py
@@ -394,11 +394,14 @@ class PickAndPlaceReceptacleTaskSampler(AbstractPickAndPlaceObjectTargetTaskSamp
             added.update(receptacle_added_objects)
             self.config.task_config.added_objects = added
 
-    def _sample_task(self, env: CPUMujocoEnv):
+    @property
+    def task_class(self):
         from molmo_spaces.tasks.pick_and_place_task import PickAndPlaceTask
 
+        return PickAndPlaceTask
+
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
         self._configure_pick_and_place(env)
-        return PickAndPlaceTask(env, self.config)
 
 
 class PickAndPlaceTaskSampler(PickAndPlaceReceptacleTaskSampler):

--- a/molmo_spaces/tasks/pick_and_place_task_sampler.py
+++ b/molmo_spaces/tasks/pick_and_place_task_sampler.py
@@ -394,14 +394,13 @@ class PickAndPlaceReceptacleTaskSampler(AbstractPickAndPlaceObjectTargetTaskSamp
             added.update(receptacle_added_objects)
             self.config.task_config.added_objects = added
 
-    @property
-    def task_class(self):
+    def _sample_task(self, env: CPUMujocoEnv, task=None):
         from molmo_spaces.tasks.pick_and_place_task import PickAndPlaceTask
 
-        return PickAndPlaceTask
-
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
         self._configure_pick_and_place(env)
+        if task is None:
+            task = PickAndPlaceTask(env, self.config)
+        return task
 
 
 class PickAndPlaceTaskSampler(PickAndPlaceReceptacleTaskSampler):

--- a/molmo_spaces/tasks/pick_task_sampler.py
+++ b/molmo_spaces/tasks/pick_task_sampler.py
@@ -140,6 +140,8 @@ class PickTaskSampler(BaseMujocoTaskSampler):
     House order (`house_inds`) and samples per house are provided via config.
     """
 
+    task_cls = PickTask
+
     def __init__(self, config: "PickBaseConfig") -> None:
         super().__init__(config)
         self.candidate_objects: None | list[MlSpacesObject] = None
@@ -790,8 +792,8 @@ class PickTaskSampler(BaseMujocoTaskSampler):
 
         return expression_priority, filtered_expression_priority
 
-    def _sample_task(self, env: CPUMujocoEnv) -> PickTask:
-        """Sample a pick task configuration and create the task."""
+    def _configure_episode(self, env: CPUMujocoEnv) -> None:
+        """Sample a pick task configuration."""
         assert env.current_batch_index == 0
         assert self.candidate_objects is not None and len(self.candidate_objects) > 0
 
@@ -825,16 +827,6 @@ class PickTaskSampler(BaseMujocoTaskSampler):
 
         if self._datagen_profiler is not None:
             self._datagen_profiler.end("sample_context_expressions")
-
-        if self._datagen_profiler is not None:
-            self._datagen_profiler.start("sample_task_create")
-
-        task = PickTask(env, self.config)
-
-        if self._datagen_profiler is not None:
-            self._datagen_profiler.end("sample_task_create")
-
-        return task
 
     def _get_scene_objects(self, env: CPUMujocoEnv, mass_limit=100) -> list[MlSpacesObject]:
         """

--- a/molmo_spaces/tasks/pick_task_sampler.py
+++ b/molmo_spaces/tasks/pick_task_sampler.py
@@ -140,8 +140,6 @@ class PickTaskSampler(BaseMujocoTaskSampler):
     House order (`house_inds`) and samples per house are provided via config.
     """
 
-    task_cls = PickTask
-
     def __init__(self, config: "PickBaseConfig") -> None:
         super().__init__(config)
         self.candidate_objects: None | list[MlSpacesObject] = None
@@ -792,8 +790,12 @@ class PickTaskSampler(BaseMujocoTaskSampler):
 
         return expression_priority, filtered_expression_priority
 
-    def _configure_episode(self, env: CPUMujocoEnv) -> None:
-        """Sample a pick task configuration."""
+    def _sample_task(self, env: CPUMujocoEnv, task: PickTask | None = None) -> PickTask:
+        """Sample a pick task configuration and create the task.
+
+        If ``task`` is given, configure that task's episode instead of building
+        one (see ``EpisodeSource.SELF``); it must be returned either way.
+        """
         assert env.current_batch_index == 0
         assert self.candidate_objects is not None and len(self.candidate_objects) > 0
 
@@ -827,6 +829,17 @@ class PickTaskSampler(BaseMujocoTaskSampler):
 
         if self._datagen_profiler is not None:
             self._datagen_profiler.end("sample_context_expressions")
+
+        if self._datagen_profiler is not None:
+            self._datagen_profiler.start("sample_task_create")
+
+        if task is None:
+            task = PickTask(env, self.config)
+
+        if self._datagen_profiler is not None:
+            self._datagen_profiler.end("sample_task_create")
+
+        return task
 
     def _get_scene_objects(self, env: CPUMujocoEnv, mass_limit=100) -> list[MlSpacesObject]:
         """

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -50,9 +50,17 @@ class BaseMujocoTask(gym.Env, ABC):
       resulting sim env. This is the gymnasium entry point.
 
     See ``docs/gym_compatibility.md`` for which parts of the gymnasium contract
-    hold; notably there is no ``action_space`` and only ``n_batch == 1`` is
-    supported.
+    hold. Notably neither ``action_space`` nor ``observation_space`` is declared,
+    and only ``n_batch == 1`` is supported.
     """
+
+    metadata = {"render_modes": ["rgb_array"]}
+
+    # Deliberately not declared, see docs/gym_compatibility.md:
+    #   action_space      -- actions are dicts keyed by move group, with no space
+    #   observation_space -- sensors have per-sensor spaces, but observations are
+    #                        list[dict] (one per batch element), so no single
+    #                        space describes what reset()/step() return
 
     def __init__(
         self,
@@ -62,9 +70,14 @@ class BaseMujocoTask(gym.Env, ABC):
         task_sampler: "BaseMujocoTaskSampler | None" = None,
         configure: bool = False,
         episode_options: dict[str, Any] | None = None,
+        render_mode: str | None = None,
+        render_camera: str | None = None,
     ) -> None:
         if exp_config is None:
             raise ValueError("exp_config is required")
+
+        self.render_mode = render_mode
+        self.render_camera = render_camera
 
         self._sampler = task_sampler
         self._owns_sampler = False
@@ -123,6 +136,30 @@ class BaseMujocoTask(gym.Env, ABC):
 
         # Please don't call self.reset() here. reset should return the first observation, if we do it in
         # __init__ it will end up in the cache, but not being returned to the user.
+
+    def render(self) -> np.ndarray:
+        """Render the current scene as an RGB array.
+
+        Uses ``render_camera`` if set, else the first camera in the camera config.
+        Unlike ``gym.Env.render`` this does not require ``render_mode`` to have
+        been set -- returning a frame beats returning None for an unset mode.
+        """
+        if self.render_mode not in (None, "rgb_array"):
+            raise ValueError(
+                f"Unsupported render_mode {self.render_mode!r}; supported: 'rgb_array'."
+            )
+
+        camera_name = self.render_camera
+        if camera_name is None:
+            camera_config = self.config.camera_config
+            if camera_config is None or not camera_config.cameras:
+                raise RuntimeError(
+                    "Cannot render: no cameras configured. Set exp_config.camera_config "
+                    "or this task's render_camera."
+                )
+            camera_name = camera_config.cameras[0].name
+
+        return self._env.render_rgb_frame(camera_name)
 
     def _configure_own_episode(
         self,

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -17,6 +17,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+import gymnasium as gym
 import numpy as np
 from numpy.typing import NDArray
 
@@ -24,22 +25,55 @@ from molmo_spaces.env.abstract_sensors import SensorSuite
 from molmo_spaces.env.data_views import MlSpacesObjectAbstract
 from molmo_spaces.env.env import BaseMujocoEnv
 from molmo_spaces.env.object_manager import ObjectManager
+from molmo_spaces.tasks.task_sampler_errors import EpisodesExhausted
 
 if TYPE_CHECKING:
     from molmo_spaces.configs import BaseMujocoTaskConfig
     from molmo_spaces.configs.abstract_exp_config import MlSpacesExpConfig
     from molmo_spaces.policy.base_policy import BasePolicy
+    from molmo_spaces.tasks.task_sampler import BaseMujocoTaskSampler
 
 
 log = logging.getLogger(__name__)
 
 
-class BaseMujocoTask(ABC):
+class BaseMujocoTask(gym.Env, ABC):
+    """A task, and the gymnasium env for that task.
+
+    Two ways to build one:
+
+    * ``Task(sim_env, exp_config)`` -- the sampler has already configured the
+      episode in ``sim_env``; this is what ``BaseMujocoTaskSampler._sample_task``
+      does and what data generation uses.
+    * ``Task(exp_config=cfg, configure=True)`` -- the task creates its own
+      sampler, has it prepare a scene and sample an episode, and binds to the
+      resulting sim env. This is the gymnasium entry point.
+
+    See ``docs/gym_compatibility.md`` for which parts of the gymnasium contract
+    hold; notably there is no ``action_space`` and only ``n_batch == 1`` is
+    supported.
+    """
+
     def __init__(
         self,
-        env: BaseMujocoEnv,
-        exp_config: "MlSpacesExpConfig",
+        env: BaseMujocoEnv | None = None,
+        exp_config: "MlSpacesExpConfig | None" = None,
+        *,
+        task_sampler: "BaseMujocoTaskSampler | None" = None,
+        configure: bool = False,
+        episode_options: dict[str, Any] | None = None,
     ) -> None:
+        if exp_config is None:
+            raise ValueError("exp_config is required")
+
+        self._sampler = task_sampler
+        self._owns_sampler = False
+
+        if configure:
+            env = self._configure_own_episode(exp_config, episode_options)
+        elif env is None:
+            raise ValueError("env is required unless configure=True")
+
         self._bind_env(env, exp_config)
         self._task_horizon = (
             exp_config.task_horizon if exp_config.task_horizon is not None else np.inf
@@ -80,8 +114,54 @@ class BaseMujocoTask(ABC):
 
         self._on_episode_configured()
 
+        if configure:
+            self._finalize_own_episode()
+
         # Please don't call self.reset() here. reset should return the first observation, if we do it in
         # __init__ it will end up in the cache, but not being returned to the user.
+
+    def _configure_own_episode(
+        self,
+        exp_config: "MlSpacesExpConfig",
+        episode_options: dict[str, Any] | None = None,
+    ) -> BaseMujocoEnv:
+        """Have this task's sampler prepare a scene and sample an episode into it.
+
+        Runs the same sampler steps, in the same order, as
+        ``BaseMujocoTaskSampler._sample_task`` -- the difference being that the
+        task already exists, so there is nothing to construct.
+
+        Returns:
+            The sim env the episode was sampled into. Note this is read from the
+            sampler *after* preparing the scene, because loading a scene replaces
+            the sim env.
+        """
+        if self._sampler is None:
+            self._sampler = exp_config.task_sampler_config.task_sampler_class(exp_config)
+            self._owns_sampler = True
+
+        if not self._sampler.prepare_episode(**(episode_options or {})):
+            raise EpisodesExhausted(
+                f"{type(self._sampler).__name__} is out of tasks (max_tasks reached); "
+                f"call task_sampler.reset() to start over."
+            )
+
+        sim_env = self._sampler.env
+        if sim_env.n_batch != 1:
+            raise ValueError(
+                f"The gymnasium interface is single-environment only, got "
+                f"n_batch={sim_env.n_batch}. Use the task sampler directly for batches."
+            )
+
+        self._sampler._configure_episode(sim_env)
+        return sim_env
+
+    def _finalize_own_episode(self) -> None:
+        """Run the sampler's post-construction steps against this task."""
+        if self._sampler is None:
+            return
+        self._sampler._post_construct(self)
+        self._sampler.finalize_episode(self)
 
     def _bind_env(self, env: BaseMujocoEnv, exp_config: "MlSpacesExpConfig") -> None:
         """Point this task at ``env`` and derive the step ratios from its model.

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -40,15 +40,7 @@ class BaseMujocoTask(ABC):
         env: BaseMujocoEnv,
         exp_config: "MlSpacesExpConfig",
     ) -> None:
-        self._env = env
-        self._ctrl_dt_ms = exp_config.ctrl_dt_ms
-        sim_dt_ms = round(self._env.mj_model.opt.timestep * 1000)
-        if self._ctrl_dt_ms % sim_dt_ms != 0:
-            raise ValueError(
-                f"Control dt {self._ctrl_dt_ms}ms is not divisible by sim dt {sim_dt_ms}ms"
-            )
-        self._n_sim_steps_per_ctrl = int(self._ctrl_dt_ms // sim_dt_ms)
-        self._n_ctrl_steps_per_policy = int(exp_config.policy_dt_ms // self._ctrl_dt_ms)
+        self._bind_env(env, exp_config)
         self._task_horizon = (
             exp_config.task_horizon if exp_config.task_horizon is not None else np.inf
         )
@@ -90,6 +82,25 @@ class BaseMujocoTask(ABC):
 
         # Please don't call self.reset() here. reset should return the first observation, if we do it in
         # __init__ it will end up in the cache, but not being returned to the user.
+
+    def _bind_env(self, env: BaseMujocoEnv, exp_config: "MlSpacesExpConfig") -> None:
+        """Point this task at ``env`` and derive the step ratios from its model.
+
+        Loading a scene builds a *new* ``CPUMujocoEnv`` around the newly compiled
+        model (see ``BaseMujocoTaskSampler.update_scene``), so a task that outlives
+        a scene change has to re-bind rather than keep its original env: the sim
+        timestep, and hence the number of sim steps per control step, comes from
+        ``env.mj_model``.
+        """
+        self._env = env
+        self._ctrl_dt_ms = exp_config.ctrl_dt_ms
+        sim_dt_ms = round(env.mj_model.opt.timestep * 1000)
+        if self._ctrl_dt_ms % sim_dt_ms != 0:
+            raise ValueError(
+                f"Control dt {self._ctrl_dt_ms}ms is not divisible by sim dt {sim_dt_ms}ms"
+            )
+        self._n_sim_steps_per_ctrl = int(self._ctrl_dt_ms // sim_dt_ms)
+        self._n_ctrl_steps_per_policy = int(exp_config.policy_dt_ms // self._ctrl_dt_ms)
 
     def _on_episode_configured(self) -> None:  # noqa: B027 - optional hook, not abstract
         """Derive per-episode state from ``self.config`` and the current scene.

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -56,14 +56,18 @@ class BaseMujocoTask(gym.Env, ABC):
 
     Two ways to build one:
 
-    * ``Task(sim_env, exp_config)`` -- ``EpisodeSource.SAMPLER``: the sampler
-      has already configured the episode in ``sim_env``; this is what
+    Which one you get follows from the arguments, and is recorded as
+    ``episode_source``:
+
+    * ``Task(sim_env, exp_config)`` -- ``EpisodeSource.SAMPLER``: a sampler has
+      already configured the episode in ``sim_env``; this is what
       ``BaseMujocoTaskSampler._sample_task`` does and what data generation uses.
-    * ``Task(exp_config=cfg, episode_source="self")`` -- ``EpisodeSource.SELF``:
-      the task creates its own sampler (or uses ``task_sampler``), has it prepare
-      a scene and sample an episode, and binds to the resulting sim env. This is
-      the gymnasium entry point, and the only mode whose ``reset()`` advances to
-      a new episode.
+      ``reset()`` clears task state and leaves the scene alone.
+    * ``Task(exp_config=cfg)`` (no env) -- ``EpisodeSource.SELF``: the task
+      creates its own sampler, or uses ``task_sampler``, has it prepare a scene
+      and sample an episode, and binds to the resulting sim env. This is the
+      gymnasium entry point, and ``reset()`` samples a new episode. Note that
+      omitting the env therefore triggers a scene load.
 
     See ``docs/gym_compatibility.md`` for which parts of the gymnasium contract
     hold. Notably neither ``action_space`` nor ``observation_space`` is declared,
@@ -84,7 +88,6 @@ class BaseMujocoTask(gym.Env, ABC):
         exp_config: "MlSpacesExpConfig | None" = None,
         *,
         task_sampler: "BaseMujocoTaskSampler | None" = None,
-        episode_source: "EpisodeSource | str" = EpisodeSource.SAMPLER,
         episode_options: dict[str, Any] | None = None,
         render_mode: str | None = None,
         render_camera: str | None = None,
@@ -95,30 +98,24 @@ class BaseMujocoTask(gym.Env, ABC):
         self.render_mode = render_mode
         self.render_camera = render_camera
 
-        self.episode_source = EpisodeSource(episode_source)
+        # An env means a sampler already configured this episode; no env means the
+        # task samples its own, so there is nothing else the mode could be.
+        self.episode_source = EpisodeSource.SAMPLER if env is not None else EpisodeSource.SELF
         self._sampler = task_sampler
         self._owns_sampler = False
 
+        self._episode_is_fresh = self.episode_source is EpisodeSource.SELF
+
         if self.episode_source is EpisodeSource.SELF:
-            if env is not None:
-                raise ValueError(
-                    "episode_source='self' means the task samples its own episode, "
-                    "so it binds the sampler's env; do not pass one."
-                )
-            self._episode_is_fresh = True
-            env = self._configure_own_episode(exp_config, episode_options)
+            env = self._start_episode(exp_config, episode_options)
         else:
-            if env is None:
-                raise ValueError("env is required for episode_source='sampler'")
             if task_sampler is not None:
                 raise ValueError(
-                    "episode_source='sampler' means a sampler built this episode "
-                    "already; pass episode_source='self' to let the task advance "
-                    "episodes with the given sampler."
+                    "A task built around an existing env already has its episode; "
+                    "omit env to have the task sample its own with this sampler."
                 )
             if episode_options:
-                raise ValueError("episode_options only applies to episode_source='self'")
-            self._episode_is_fresh = False
+                raise ValueError("episode_options requires the task to sample its own episode")
 
         self._bind_env(env, exp_config)
         self._task_horizon = (
@@ -161,7 +158,7 @@ class BaseMujocoTask(gym.Env, ABC):
         self._on_episode_configured()
 
         if self.episode_source is EpisodeSource.SELF:
-            self._finalize_own_episode()
+            self._sampler.finalize_episode(self)
 
         # Please don't call self.reset() here. reset should return the first observation, if we do it in
         # __init__ it will end up in the cache, but not being returned to the user.
@@ -190,7 +187,7 @@ class BaseMujocoTask(gym.Env, ABC):
 
         return self._env.render_rgb_frame(camera_name)
 
-    def _configure_own_episode(
+    def _start_episode(
         self,
         exp_config: "MlSpacesExpConfig",
         episode_options: dict[str, Any] | None = None,
@@ -233,8 +230,6 @@ class BaseMujocoTask(gym.Env, ABC):
             )
         return sim_env
 
-    _EPISODE_OPTIONS = frozenset({"house_index", "force_advance_scene"})
-
     def _resample_episode(
         self,
         seed: int | None = None,
@@ -243,18 +238,14 @@ class BaseMujocoTask(gym.Env, ABC):
         """Sample a fresh episode into this task, for gymnasium-style reset().
 
         The first call after construction is a no-op unless a seed or options are
-        given: ``__init__`` already sampled an episode, and re-sampling it would
-        throw away that work (a scene load, in the worst case) before the caller
-        ever saw it.
-        """
-        if options:
-            unknown = set(options) - self._EPISODE_OPTIONS
-            if unknown:
-                raise ValueError(
-                    f"Unsupported reset options {sorted(unknown)}; "
-                    f"supported: {sorted(self._EPISODE_OPTIONS)}"
-                )
+        given: ``__init__`` already sampled an episode. Re-sampling it would not
+        just waste the work -- samplers consume their candidate pool per house
+        (see ``PickTaskSampler``), so every extra episode brings the next
+        ``HouseInvalidForTask`` closer.
 
+        Options are whatever ``BaseMujocoTaskSampler.prepare_episode`` accepts
+        (``house_index``, ``force_advance_scene``); anything else is its TypeError.
+        """
         if self._episode_is_fresh and seed is None and not options:
             self._episode_is_fresh = False
             return
@@ -262,19 +253,13 @@ class BaseMujocoTask(gym.Env, ABC):
         if seed is not None:
             self._sampler.seed_task_sampling(seed)
 
-        sim_env = self._configure_own_episode(self.config, options)
+        sim_env = self._start_episode(self.config, options)
         # A scene load replaces the sim env, so re-bind rather than assume ours
         # is still the live one.
         self._bind_env(sim_env, self.config)
         self._on_episode_configured()
-        self._finalize_own_episode()
-        self._episode_is_fresh = False
-
-    def _finalize_own_episode(self) -> None:
-        """Run the sampler's end-of-episode setup against this task."""
-        if self._sampler is None:
-            return
         self._sampler.finalize_episode(self)
+        self._episode_is_fresh = False
 
     def _bind_env(self, env: BaseMujocoEnv, exp_config: "MlSpacesExpConfig") -> None:
         """Point this task at ``env`` and derive the step ratios from its model.
@@ -443,9 +428,7 @@ class BaseMujocoTask(gym.Env, ABC):
     ):
         """Reset the task and record initial observations.
 
-        With ``EpisodeSource.SELF`` this samples a *new* episode, except on the
-        first call, which uses the episode built during construction -- passing
-        ``seed`` forces a re-sample so the seed takes effect. With
+        With ``EpisodeSource.SELF`` this samples a *new* episode every time. With
         ``EpisodeSource.SAMPLER`` there is no sampler to re-sample with, so the
         scene is left alone and only task state is cleared; a new episode means a
         new ``sample_task()``.
@@ -454,8 +437,8 @@ class BaseMujocoTask(gym.Env, ABC):
             seed: Seeds episode sampling. NOTE this is process-global (see
                 ``BaseMujocoTaskSampler.seed_task_sampling``), so it perturbs
                 the RNG of everything else in the process, callers included.
-            options: Forwarded to episode sampling; only ``house_index`` and
-                ``force_advance_scene`` are accepted.
+            options: Forwarded to ``BaseMujocoTaskSampler.prepare_episode``, so
+                ``house_index`` and ``force_advance_scene``.
         """
         super().reset(seed=seed)
 

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -15,6 +15,7 @@ Action Noise:
 import contextlib
 import logging
 from abc import ABC, abstractmethod
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import gymnasium as gym
@@ -37,17 +38,32 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+class EpisodeSource(StrEnum):
+    """Where a task's episodes come from, and so what ``reset()`` does."""
+
+    SAMPLER = "sampler"
+    """A task sampler configured this episode and built the task for it. reset()
+    clears task state and leaves the scene alone; a new episode means another
+    ``sample_task()``. This is the data generation and evaluation path."""
+
+    SELF = "self"
+    """The task holds a sampler and advances its own episodes. reset() samples a
+    new one. This is the gymnasium path."""
+
+
 class BaseMujocoTask(gym.Env, ABC):
     """A task, and the gymnasium env for that task.
 
     Two ways to build one:
 
-    * ``Task(sim_env, exp_config)`` -- the sampler has already configured the
-      episode in ``sim_env``; this is what ``BaseMujocoTaskSampler._sample_task``
-      does and what data generation uses.
-    * ``Task(exp_config=cfg, configure=True)`` -- the task creates its own
-      sampler, has it prepare a scene and sample an episode, and binds to the
-      resulting sim env. This is the gymnasium entry point.
+    * ``Task(sim_env, exp_config)`` -- ``EpisodeSource.SAMPLER``: the sampler
+      has already configured the episode in ``sim_env``; this is what
+      ``BaseMujocoTaskSampler._sample_task`` does and what data generation uses.
+    * ``Task(exp_config=cfg, episode_source="self")`` -- ``EpisodeSource.SELF``:
+      the task creates its own sampler (or uses ``task_sampler``), has it prepare
+      a scene and sample an episode, and binds to the resulting sim env. This is
+      the gymnasium entry point, and the only mode whose ``reset()`` advances to
+      a new episode.
 
     See ``docs/gym_compatibility.md`` for which parts of the gymnasium contract
     hold. Notably neither ``action_space`` nor ``observation_space`` is declared,
@@ -68,7 +84,7 @@ class BaseMujocoTask(gym.Env, ABC):
         exp_config: "MlSpacesExpConfig | None" = None,
         *,
         task_sampler: "BaseMujocoTaskSampler | None" = None,
-        configure: bool = False,
+        episode_source: "EpisodeSource | str" = EpisodeSource.SAMPLER,
         episode_options: dict[str, Any] | None = None,
         render_mode: str | None = None,
         render_camera: str | None = None,
@@ -79,17 +95,30 @@ class BaseMujocoTask(gym.Env, ABC):
         self.render_mode = render_mode
         self.render_camera = render_camera
 
+        self.episode_source = EpisodeSource(episode_source)
         self._sampler = task_sampler
         self._owns_sampler = False
-        # Whether this task samples its own episodes, and so whether reset()
-        # advances to a new one.
-        self._self_configured = configure
-        self._episode_is_fresh = configure
 
-        if configure:
+        if self.episode_source is EpisodeSource.SELF:
+            if env is not None:
+                raise ValueError(
+                    "episode_source='self' means the task samples its own episode, "
+                    "so it binds the sampler's env; do not pass one."
+                )
+            self._episode_is_fresh = True
             env = self._configure_own_episode(exp_config, episode_options)
-        elif env is None:
-            raise ValueError("env is required unless configure=True")
+        else:
+            if env is None:
+                raise ValueError("env is required for episode_source='sampler'")
+            if task_sampler is not None:
+                raise ValueError(
+                    "episode_source='sampler' means a sampler built this episode "
+                    "already; pass episode_source='self' to let the task advance "
+                    "episodes with the given sampler."
+                )
+            if episode_options:
+                raise ValueError("episode_options only applies to episode_source='self'")
+            self._episode_is_fresh = False
 
         self._bind_env(env, exp_config)
         self._task_horizon = (
@@ -131,7 +160,7 @@ class BaseMujocoTask(gym.Env, ABC):
 
         self._on_episode_configured()
 
-        if configure:
+        if self.episode_source is EpisodeSource.SELF:
             self._finalize_own_episode()
 
         # Please don't call self.reset() here. reset should return the first observation, if we do it in
@@ -408,12 +437,12 @@ class BaseMujocoTask(gym.Env, ABC):
     ):
         """Reset the task and record initial observations.
 
-        For a self-configured task (``configure=True``) this samples a *new*
-        episode, except on the first call, which uses the episode built during
-        construction -- passing ``seed`` forces a re-sample so the seed takes
-        effect. For a sampler-built task there is no sampler to re-sample with,
-        so the scene is left alone and only task state is cleared; a new episode
-        means a new ``sample_task()``.
+        With ``EpisodeSource.SELF`` this samples a *new* episode, except on the
+        first call, which uses the episode built during construction -- passing
+        ``seed`` forces a re-sample so the seed takes effect. With
+        ``EpisodeSource.SAMPLER`` there is no sampler to re-sample with, so the
+        scene is left alone and only task state is cleared; a new episode means a
+        new ``sample_task()``.
 
         Args:
             seed: Seeds episode sampling. NOTE this is process-global (see
@@ -424,7 +453,7 @@ class BaseMujocoTask(gym.Env, ABC):
         """
         super().reset(seed=seed)
 
-        if self._self_configured:
+        if self.episode_source is EpisodeSource.SELF:
             self._resample_episode(seed=seed, options=options)
 
         self.episode_step_count = 0

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -68,6 +68,10 @@ class BaseMujocoTask(gym.Env, ABC):
 
         self._sampler = task_sampler
         self._owns_sampler = False
+        # Whether this task samples its own episodes, and so whether reset()
+        # advances to a new one.
+        self._self_configured = configure
+        self._episode_is_fresh = configure
 
         if configure:
             env = self._configure_own_episode(exp_config, episode_options)
@@ -155,6 +159,43 @@ class BaseMujocoTask(gym.Env, ABC):
 
         self._sampler._configure_episode(sim_env)
         return sim_env
+
+    _EPISODE_OPTIONS = frozenset({"house_index", "force_advance_scene"})
+
+    def _resample_episode(
+        self,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        """Sample a fresh episode into this task, for gymnasium-style reset().
+
+        The first call after construction is a no-op unless a seed or options are
+        given: ``__init__`` already sampled an episode, and re-sampling it would
+        throw away that work (a scene load, in the worst case) before the caller
+        ever saw it.
+        """
+        if options:
+            unknown = set(options) - self._EPISODE_OPTIONS
+            if unknown:
+                raise ValueError(
+                    f"Unsupported reset options {sorted(unknown)}; "
+                    f"supported: {sorted(self._EPISODE_OPTIONS)}"
+                )
+
+        if self._episode_is_fresh and seed is None and not options:
+            self._episode_is_fresh = False
+            return
+
+        if seed is not None:
+            self._sampler.seed_task_sampling(seed)
+
+        sim_env = self._configure_own_episode(self.config, options)
+        # A scene load replaces the sim env, so re-bind rather than assume ours
+        # is still the live one.
+        self._bind_env(sim_env, self.config)
+        self._on_episode_configured()
+        self._finalize_own_episode()
+        self._episode_is_fresh = False
 
     def _finalize_own_episode(self) -> None:
         """Run the sampler's post-construction steps against this task."""
@@ -322,11 +363,32 @@ class BaseMujocoTask(gym.Env, ABC):
 
         return observation, reward, terminated, truncated, info
 
-    def reset(self):
-        """Reset the task and record initial observations."""
-        # TODO(rose): Something like this should be done here to be compatible with gym API
-        # consider placing settle_scene here.
-        # self._env.reset()
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ):
+        """Reset the task and record initial observations.
+
+        For a self-configured task (``configure=True``) this samples a *new*
+        episode, except on the first call, which uses the episode built during
+        construction -- passing ``seed`` forces a re-sample so the seed takes
+        effect. For a sampler-built task there is no sampler to re-sample with,
+        so the scene is left alone and only task state is cleared; a new episode
+        means a new ``sample_task()``.
+
+        Args:
+            seed: Seeds episode sampling. NOTE this is process-global (see
+                ``BaseMujocoTaskSampler.seed_task_sampling``), so it perturbs
+                the RNG of everything else in the process, callers included.
+            options: Forwarded to episode sampling; only ``house_index`` and
+                ``force_advance_scene`` are accepted.
+        """
+        super().reset(seed=seed)
+
+        if self._self_configured:
+            self._resample_episode(seed=seed, options=options)
 
         self.episode_step_count = 0
         self._cumulative_reward = np.zeros(self._env.n_batch)
@@ -638,6 +700,12 @@ class BaseMujocoTask(gym.Env, ABC):
 
         # Clear environment reference (not closing it as it is owned by the task sampler)
         self._env = None
+
+        # A self-configured task created its own sampler, so it owns the sim env
+        # behind it and has to close it; a sampler passed in belongs to the caller.
+        if getattr(self, "_owns_sampler", False) and self._sampler is not None:
+            self._sampler.close()
+            self._sampler = None
 
         if hasattr(self, "renderer") and self.renderer is not None:
             with contextlib.suppress(AttributeError):

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -197,9 +197,9 @@ class BaseMujocoTask(gym.Env, ABC):
     ) -> BaseMujocoEnv:
         """Have this task's sampler prepare a scene and sample an episode into it.
 
-        Runs the same sampler steps, in the same order, as
-        ``BaseMujocoTaskSampler._sample_task`` -- the difference being that the
-        task already exists, so there is nothing to construct.
+        Runs the sampler's own steps -- ``prepare_episode``, then ``_sample_task``
+        with this task passed in so it configures us rather than building a second
+        task, then ``finalize_episode``.
 
         Returns:
             The sim env the episode was sampled into. Note this is read from the
@@ -223,7 +223,14 @@ class BaseMujocoTask(gym.Env, ABC):
                 f"n_batch={sim_env.n_batch}. Use the task sampler directly for batches."
             )
 
-        self._sampler._configure_episode(sim_env)
+        configured = self._sampler._sample_task(sim_env, task=self)
+        if configured is not self:
+            raise TypeError(
+                f"{type(self._sampler).__name__}._sample_task ignored its `task` "
+                f"argument and returned {type(configured).__name__} instead, so this "
+                f"task has no episode. Samplers must configure and return the task "
+                f"they are given."
+            )
         return sim_env
 
     _EPISODE_OPTIONS = frozenset({"house_index", "force_advance_scene"})
@@ -264,10 +271,9 @@ class BaseMujocoTask(gym.Env, ABC):
         self._episode_is_fresh = False
 
     def _finalize_own_episode(self) -> None:
-        """Run the sampler's post-construction steps against this task."""
+        """Run the sampler's end-of-episode setup against this task."""
         if self._sampler is None:
             return
-        self._sampler._post_construct(self)
         self._sampler.finalize_episode(self)
 
     def _bind_env(self, env: BaseMujocoEnv, exp_config: "MlSpacesExpConfig") -> None:

--- a/molmo_spaces/tasks/task.py
+++ b/molmo_spaces/tasks/task.py
@@ -86,8 +86,18 @@ class BaseMujocoTask(ABC):
         # Optional profiler for granular timing (set via set_datagen_profiler)
         self._datagen_profiler = None
 
+        self._on_episode_configured()
+
         # Please don't call self.reset() here. reset should return the first observation, if we do it in
         # __init__ it will end up in the cache, but not being returned to the user.
+
+    def _on_episode_configured(self) -> None:  # noqa: B027 - optional hook, not abstract
+        """Derive per-episode state from ``self.config`` and the current scene.
+
+        Anything a task caches from its config or the scene belongs here rather
+        than in ``__init__``, so it can be recomputed when the same task object is
+        pointed at a freshly sampled episode.
+        """
 
     @property
     def sensor_suite(self) -> SensorSuite | None:

--- a/molmo_spaces/tasks/task_sampler.py
+++ b/molmo_spaces/tasks/task_sampler.py
@@ -512,53 +512,22 @@ class BaseMujocoTaskSampler:
 
         return visibility_resolver
 
-    # Task class this sampler instantiates. Subclasses either set this, or override
-    # the `task_class` property when the class is only known at runtime (e.g. read
-    # off the task config, or imported lazily to avoid a circular import).
-    task_cls: type[BaseMujocoTask] | None = None
-
-    @property
-    def task_class(self) -> type[BaseMujocoTask]:
-        """The task class to instantiate for the configured episode."""
-        if self.task_cls is None:
-            raise NotImplementedError(
-                f"{type(self).__name__} must set `task_cls` or override `task_class`."
-            )
-        return self.task_cls
-
     @abstractmethod
-    def _configure_episode(self, env: BaseMujocoEnv) -> None:
-        """Sample this episode: mutate ``self.config.task_config`` and the scene.
+    def _sample_task(
+        self,
+        env: BaseMujocoEnv,
+        task: BaseMujocoTask | None = None,
+    ) -> BaseMujocoTask:
+        """Sample this episode into ``env`` and return the task for it.
 
-        Everything an episode needs must land in the config or the simulation
-        state, so that constructing the task afterwards is a pure step. This
-        separation is what lets a task configure itself (see
-        :meth:`BaseMujocoTask.__init__`) instead of being built by the sampler.
+        Mutates ``self.config.task_config`` and the scene, then builds the task.
+        If ``task`` is given, configure *that* task's episode rather than building
+        one -- this is how a task samples its own episodes
+        (``EpisodeSource.SELF``, see :meth:`BaseMujocoTask.__init__`). Either way
+        the task in play must be returned; ignoring ``task`` and returning a
+        different object is an error the caller checks for.
         """
         raise NotImplementedError
-
-    def _post_construct(self, task: BaseMujocoTask) -> None:
-        """Hook for state that can only be attached after the task exists."""
-
-    def _sample_task(self, env: BaseMujocoEnv, **configure_kwargs: Any) -> BaseMujocoTask:
-        """Configure an episode and build the task for it.
-
-        Extra keyword arguments are forwarded to :meth:`_configure_episode`, which
-        is how samplers with episode options (e.g. ``skip_robot_placement``) are
-        driven by their callers.
-        """
-        self._configure_episode(env, **configure_kwargs)
-
-        if self._datagen_profiler is not None:
-            self._datagen_profiler.start("sample_task_create")
-        try:
-            task = self.task_class(env, self.config)
-        finally:
-            if self._datagen_profiler is not None:
-                self._datagen_profiler.end("sample_task_create")
-
-        self._post_construct(task)
-        return task
 
     def reset(self) -> None:
         self._house_iterator_index = -1  # -1 so that it doesn't skip the first task

--- a/molmo_spaces/tasks/task_sampler.py
+++ b/molmo_spaces/tasks/task_sampler.py
@@ -512,9 +512,53 @@ class BaseMujocoTaskSampler:
 
         return visibility_resolver
 
+    # Task class this sampler instantiates. Subclasses either set this, or override
+    # the `task_class` property when the class is only known at runtime (e.g. read
+    # off the task config, or imported lazily to avoid a circular import).
+    task_cls: type[BaseMujocoTask] | None = None
+
+    @property
+    def task_class(self) -> type[BaseMujocoTask]:
+        """The task class to instantiate for the configured episode."""
+        if self.task_cls is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} must set `task_cls` or override `task_class`."
+            )
+        return self.task_cls
+
     @abstractmethod
-    def _sample_task(self, env: BaseMujocoEnv) -> BaseMujocoTask:
+    def _configure_episode(self, env: BaseMujocoEnv) -> None:
+        """Sample this episode: mutate ``self.config.task_config`` and the scene.
+
+        Everything an episode needs must land in the config or the simulation
+        state, so that constructing the task afterwards is a pure step. This
+        separation is what lets a task configure itself (see
+        :meth:`BaseMujocoTask.__init__`) instead of being built by the sampler.
+        """
         raise NotImplementedError
+
+    def _post_construct(self, task: BaseMujocoTask) -> None:
+        """Hook for state that can only be attached after the task exists."""
+
+    def _sample_task(self, env: BaseMujocoEnv, **configure_kwargs: Any) -> BaseMujocoTask:
+        """Configure an episode and build the task for it.
+
+        Extra keyword arguments are forwarded to :meth:`_configure_episode`, which
+        is how samplers with episode options (e.g. ``skip_robot_placement``) are
+        driven by their callers.
+        """
+        self._configure_episode(env, **configure_kwargs)
+
+        if self._datagen_profiler is not None:
+            self._datagen_profiler.start("sample_task_create")
+        try:
+            task = self.task_class(env, self.config)
+        finally:
+            if self._datagen_profiler is not None:
+                self._datagen_profiler.end("sample_task_create")
+
+        self._post_construct(task)
+        return task
 
     def reset(self) -> None:
         self._house_iterator_index = -1  # -1 so that it doesn't skip the first task

--- a/molmo_spaces/tasks/task_sampler.py
+++ b/molmo_spaces/tasks/task_sampler.py
@@ -1058,17 +1058,24 @@ class BaseMujocoTaskSampler:
                 self._datagen_profiler.end("randomize_dynamics")
             log.info("Dynamics randomization completed.\n")
 
-    def sample_task(
+    def prepare_episode(
         self,
         force_advance_scene=False,
         house_index=None,
-    ) -> None | BaseMujocoTask:
-        """Returns a task with batch size task_batch_size.
+    ) -> bool:
+        """Get the scene ready for one episode, up to but not including the task.
+
+        Advances house iteration, loads or reuses the scene, applies scene
+        randomization and flushes metadata. Afterwards ``self.env`` is the env to
+        build the episode in -- note that loading a scene *replaces* it.
 
         Args:
             force_advance_scene: Whether to force advancing to the next scene
             house_index: Specific house index to use, overriding iteration
-            variant: Scene variant to use ("ceiling", "map", "base", etc.). Defaults to "ceiling".
+
+        Returns:
+            False if the sampler is out of tasks, in which case no scene work was
+            done; True otherwise.
         """
         # save the task_config at the beginning of the experiment
         if self.config.task_config_preset_exp is None:
@@ -1079,7 +1086,7 @@ class BaseMujocoTaskSampler:
         # Stopping condition for dataset workflows
         if not math.isinf(self._current_tasks_left):
             if self._current_tasks_left <= 0:
-                return None  # type: ignore[return-value]
+                return False
 
         self._increment_task_and_reset_house(
             force_advance_scene=force_advance_scene, house_index=house_index
@@ -1157,6 +1164,32 @@ class BaseMujocoTaskSampler:
         # Flush accumulated metadata from add_auxiliary_objects into scene metadata
         self._metadata_adder.add_meta(self.env.current_scene_metadata)
 
+        return True
+
+    def finalize_episode(self, task: BaseMujocoTask) -> None:
+        """Finish an episode's setup once its task exists."""
+        # Update robot-mounted camera poses to ensure they reflect the final robot state.
+        # This is needed because camera setup may happen before the final mj_forward call,
+        # and env.step() (which normally updates cameras) hasn't been called yet.
+        self.env.camera_manager.registry.update_all_cameras(self.env)
+        log.info(f"Sampled task '{task.get_task_description()}'")
+
+    def sample_task(
+        self,
+        force_advance_scene=False,
+        house_index=None,
+    ) -> None | BaseMujocoTask:
+        """Returns a task with batch size task_batch_size.
+
+        Args:
+            force_advance_scene: Whether to force advancing to the next scene
+            house_index: Specific house index to use, overriding iteration
+        """
+        if not self.prepare_episode(
+            force_advance_scene=force_advance_scene, house_index=house_index
+        ):
+            return None  # type: ignore[return-value]
+
         # Time task-specific sampling (object selection, robot placement, camera setup, etc.)
         if self._datagen_profiler is not None:
             self._datagen_profiler.start("task_specific_sample")
@@ -1166,11 +1199,7 @@ class BaseMujocoTaskSampler:
             if self._datagen_profiler is not None:
                 self._datagen_profiler.end("task_specific_sample")
 
-        # Update robot-mounted camera poses to ensure they reflect the final robot state.
-        # This is needed because camera setup may happen before the final mj_forward call,
-        # and env.step() (which normally updates cameras) hasn't been called yet.
-        self.env.camera_manager.registry.update_all_cameras(self.env)
-        log.info(f"Sampled task '{task.get_task_description()}'")
+        self.finalize_episode(task)
 
         return task
 

--- a/molmo_spaces/tasks/task_sampler_errors.py
+++ b/molmo_spaces/tasks/task_sampler_errors.py
@@ -45,3 +45,11 @@ class HouseInvalidForTask(Exception):
             message = "House invalid for tasks due to physics constraints"
 
         super().__init__(message)
+
+
+class EpisodesExhausted(Exception):
+    """A task sampler bounded by ``max_tasks`` has no episodes left.
+
+    The sampler-driven path signals this by returning ``None`` from
+    ``sample_task()``; the gymnasium path has no equivalent, so it raises.
+    """


### PR DESCRIPTION
Tasks become `gymnasium.Env`s that can sample their own episodes, so envs can be registered and built with `gymnasium.make`. Data generation keeps its existing entry point (`task_sampler.sample_task()`) and its semantics unchanged.

```python
# datagen / eval -- unchanged
task = task_sampler.sample_task()

# gymnasium: omit the env and the task samples its own episode
task = exp_config.task_config.task_cls(exp_config=cfg)
obs, info = task.reset()
frame = task.render()

gym_registration.register_configs()          # 39 envs, MolmoSpaces/<ConfigName>-v0
env = gymnasium.make("MolmoSpaces/FrankaPickDroidDataGenConfig-v0")
```

## How it works

`_sample_task(env, task=None)` either builds a task or configures the one it is given, so a task can sample its own episode by passing itself in. `sample_task()` splits into `prepare_episode` (scene, house iteration, randomization) -> `_sample_task` -> `finalize_episode`, and both paths run those same steps in the same order.

`EpisodeSource` is derived from the arguments: an `env` means a sampler configured this episode (`SAMPLER`), no `env` means the task samples its own (`SELF`). Only `SELF` advances episodes on `reset()`.

## Deliberately partial gym compatibility

Documented in `docs/gym_compatibility.md`. Compatibility stops wherever going further would change data generation:

- **No `action_space` or `observation_space`.** Actions are dicts keyed by move group; observations are `list[dict]` over the batch, so no single space describes them. Consequence: `check_env` fails and most RL libraries will not consume these envs directly. Registered envs set `disable_env_checker=True`.
- **Single env only.** `n_batch == 1` on the gym path; termination and success are index-0 only, so batching is not usable end to end.
- **`reset(seed=)` seeds process-global RNG.** Samplers draw from global `random`/`np.random` in ~70 places; localizing that would change every sampled episode and redefine what `config.seed` reproduces.
- **`reset()` semantics differ by construction path**, and re-sampling is bounded: samplers consume their per-house candidate pool, so enough resets on one house raise `HouseInvalidForTask` -- the signal datagen handles by advancing houses.
- **No cross-env scene reuse.** Each gym env owns its sampler and sim env. Samplers cannot be shared between live envs: one holds exactly one sim env, and loading a scene replaces it.

## Notable internals

- `_bind_env` re-derives the sim/control step ratio from the bound model, because loading a scene builds a new `CPUMujocoEnv` around a newly compiled model.
- `MultiTask.__init__` now calls `super().__init__` instead of re-deriving all 22 base fields by hand (verified field-for-field), so it picks up `gym.Env`'s initialization.
- `_on_episode_configured()` holds state derived from the config or scene, so it can be recomputed when a task is pointed at a fresh episode. It runs from `super().__init__`, so subclasses needing attributes during it must set them first.
- `close()` closes the sampler only when the task created it.

## Testing

Non-curobo tests match the pre-change baseline at every commit: `component_tests` 71 passed / 2 skipped, `data_generation` 132 passed (116 baseline + 16 new in `mlspaces_tests/data_generation/test_gym_env_interface.py`). Curobo tests were not run.

New tests cover the gym path, cross-path observation-key parity, reset semantics for both paths, the batched rejection, sampler exhaustion (`EpisodesExhausted` rather than `None`), render, registration, and the deliberate absence of both spaces.

## Pre-existing issues found, not fixed

- `PickAndPlaceMultiTaskSampler` passes an `llm_task` kwarg that nothing accepts -- an uncaught `TypeError`, so the `MultiPnPTask` config is already dead at `main`. It and `JsonEvalTaskSampler` do not accept the new `task` argument, so the gym path on those configs fails loudly rather than silently building the wrong class.
- `close()` raises an ignored `TypeError` at interpreter shutdown (module teardown makes `MlSpacesObjectAbstract` `None`). Reproduced at `main`.
- `json_eval_task_sampler` has a circular import when imported first. Reproduced at `main`.

Also removed a stale TODO on `reset()` suggesting `self._env.reset()`; a physics reset before re-sampling was tried and did not fix the bounded-re-sampling failure, so it was not kept. Scenes are still reused across episodes without a state reset, which is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
