### PR TITLE
(fix): adds option to bypass cached thormaps #176

### DIFF
--- a/molmo_spaces/configs/abstract_exp_config.py
+++ b/molmo_spaces/configs/abstract_exp_config.py
@@ -99,6 +99,8 @@ class MlSpacesExpConfig(Config, ABC):
 
     environment_light_intensity: float = 15000.0
 
+    no_cached_map: bool = False
+
     def model_post_init(self, _context) -> None:
         """This serves as the __init__() called after internal validation of config parameters"""
         assert (self.policy_dt_ms / self.ctrl_dt_ms).is_integer(), (

--- a/molmo_spaces/env/env.py
+++ b/molmo_spaces/env/env.py
@@ -719,7 +719,7 @@ class CPUMujocoEnv(BaseMujocoEnv):
         if "ithor" in self.current_model_path:
             model_path = Path(self.current_model_path.replace("_ceiling", ""))
             precomputed_map = model_path.parent / f"{model_path.stem}_map.png"
-            if precomputed_map.is_file():
+            if precomputed_map.is_file() and not self.config.no_cached_map:
                 thormap = iTHORMap.load(
                     path=precomputed_map.as_posix(),
                     agent_radius=agent_radius,
@@ -735,7 +735,7 @@ class CPUMujocoEnv(BaseMujocoEnv):
         elif "procthor" in self.current_model_path or "holodeck" in self.current_model_path:
             model_path = Path(self.current_model_path.replace("_ceiling", ""))
             precomputed_map = model_path.parent / f"{model_path.stem}_map.png"
-            if precomputed_map.is_file():
+            if precomputed_map.is_file() and not self.config.no_cached_map:
                 thormap = ProcTHORMap.load(
                     path=precomputed_map.as_posix(),
                     agent_radius=agent_radius,


### PR DESCRIPTION
This is just a temporary patch for #176 . Can add also a check instead to see if the occupancy map is corrupted, so the user doesn't have to use this flag when it fails when we encounter a corrupted pre-computed thormap