### PR TITLE
Fix the Robotiq finger pad seam that traps thin-walled objects

### DIFF
--- a/molmo_spaces/robots/franka.py
+++ b/molmo_spaces/robots/franka.py
@@ -215,27 +215,10 @@ class FrankaRobot(Robot):
         """Fuse each finger's two pad boxes into one, so they share no seam.
 
         Each Robotiq finger carries its pad as two stacked boxes on one body,
-        18.75 mm tall each, meeting flush: pad1 spans 0.11063-0.12937 and pad2
-        0.12938-0.14813. An object thin enough to penetrate that boundary ends up
+        pad1 and pad2. An object thin enough to penetrate that boundary ends up
         inside both boxes at once, and each pushes it out of itself and therefore
-        into the other. The contacts oppose -- measured on a paper cup, normals at
-        -0.983 carrying 1190 N and 853 N from two geoms on the *same* finger,
-        against 26 N on the whole opposite finger -- there is no equilibrium to
-        settle into, and nothing can release the object, because opening the jaws
-        moves the finger, the seam and whatever is caught in it together. The cup
-        was carried away wedged in one finger at 2703 N.
-
-        That is a collision artefact rather than a grip: one box over the same
-        span is the same shape to everything outside the gripper, and has no
-        interior boundary to catch anything on. Any thin wall, rim, lid, plate or
-        sheet can reach the seam, so this is applied unconditionally.
-
-        The surviving collider is ``pad2``, which is the geom the robot views
-        identify each finger by (see ``franka_droid_view``/``franka_cap_view``).
-        Only the local z extent changes, so the distance between the two fingers
-        -- and hence ``inter_finger_dist`` -- is untouched.
-
-        Returns how many fingers were merged.
+        into the other. The surviving collider is ``pad2``, which is the geom the
+        robot views identify each finger by. Returns how many fingers were merged.
         """
         pads: dict[str, dict[str, mujoco.MjsGeom]] = {}
         for geom in robot_spec.geoms:

--- a/molmo_spaces/robots/franka.py
+++ b/molmo_spaces/robots/franka.py
@@ -211,6 +211,54 @@ class FrankaRobot(Robot):
         log.info(f"Successfully randomized robot textures for robot '{robot_config.name}'")
 
     @classmethod
+    def merge_gripper_pads(cls, robot_spec: MjSpec) -> int:
+        """Fuse each finger's two pad boxes into one, so they share no seam.
+
+        Each Robotiq finger carries its pad as two stacked boxes on one body,
+        18.75 mm tall each, meeting flush: pad1 spans 0.11063-0.12937 and pad2
+        0.12938-0.14813. An object thin enough to penetrate that boundary ends up
+        inside both boxes at once, and each pushes it out of itself and therefore
+        into the other. The contacts oppose -- measured on a paper cup, normals at
+        -0.983 carrying 1190 N and 853 N from two geoms on the *same* finger,
+        against 26 N on the whole opposite finger -- there is no equilibrium to
+        settle into, and nothing can release the object, because opening the jaws
+        moves the finger, the seam and whatever is caught in it together. The cup
+        was carried away wedged in one finger at 2703 N.
+
+        That is a collision artefact rather than a grip: one box over the same
+        span is the same shape to everything outside the gripper, and has no
+        interior boundary to catch anything on. Any thin wall, rim, lid, plate or
+        sheet can reach the seam, so this is applied unconditionally.
+
+        The surviving collider is ``pad2``, which is the geom the robot views
+        identify each finger by (see ``franka_droid_view``/``franka_cap_view``).
+        Only the local z extent changes, so the distance between the two fingers
+        -- and hence ``inter_finger_dist`` -- is untouched.
+
+        Returns how many fingers were merged.
+        """
+        pads: dict[str, dict[str, mujoco.MjsGeom]] = {}
+        for geom in robot_spec.geoms:
+            if geom.name.endswith("_pad1") or geom.name.endswith("_pad2"):
+                pads.setdefault(geom.name[:-1], {})[geom.name[-1]] = geom
+        merged = 0
+        for finger, pair in sorted(pads.items()):
+            if set(pair) != {"1", "2"}:
+                continue
+            first, second = pair["1"], pair["2"]
+            low = min(first.pos[2] - first.size[2], second.pos[2] - second.size[2])
+            high = max(first.pos[2] + first.size[2], second.pos[2] + second.size[2])
+            second.pos = [second.pos[0], second.pos[1], (low + high) / 2.0]
+            second.size = [second.size[0], second.size[1], (high - low) / 2.0]
+            # Kept as geometry but no longer colliding: the merged box already
+            # covers its span, and two colliders over one span is the whole bug.
+            first.contype = 0
+            first.conaffinity = 0
+            merged += 1
+            log.debug("merged gripper pads for %s into %s2", finger, finger)
+        return merged
+
+    @classmethod
     def add_robot_to_scene(
         cls,
         robot_config: "FrankaRobotConfig",
@@ -251,6 +299,7 @@ class FrankaRobot(Robot):
             attach_frame = robot_body.add_frame()
 
         robot_spec = cls._load_robot_spec(robot_config, strip_meshes=strip_meshes)
+        cls.merge_gripper_pads(robot_spec)
 
         if randomize_textures:
             cls.randomize_robot_textures(robot_config, spec, prefix, robot_spec)


### PR DESCRIPTION
Each Robotiq finger carries its pad as **two stacked box colliders on one body**, 18.75 mm tall each, meeting flush:

```
left/right_pad1   spans 0.11063 .. 0.12937
left/right_pad2   spans 0.12938 .. 0.14813
```

They touch with a hundredth of a millimetre of overlap. An object thin enough to penetrate that boundary ends up inside **both** boxes at once, and each box pushes it out of itself and therefore into the other. There is no equilibrium to settle into, and nothing can release it, because opening the jaws moves the finger, the seam, and whatever is caught in it together.

## Measurement

A paper cup (6 mm rim) being turned over by the IK solver, at the peak step:

```
1190.1 N  dist -0.00380  vs right_pad2
 852.6 N  dist -0.00271  vs right_pad1
 395.1 N  dist -0.00125  vs right_pad2
  59.3 N  dist -0.00005  vs diningTable
  26.1 N  dist -0.00036  vs left_pad2      <- the entire opposite finger

pad-normal dot products:  -0.983, -1.000   (opposing)
```

Two geoms on the **same rigid finger** pushing against each other at 1190 N and 853 N, while the opposite finger carries 26 N. Peak 2703 N, sustained. The cup was carried off wedged in one finger and could not be put down.

The finger actuator is capped at 5 N, so these are **constraint forces, not actuator forces** — no force limit, contact parameter (`solref`/`solimp`) or grasp ranking can reach them. Chasing it through those knobs made it worse in every case (3786 N, 5023 N).

## Fix

`FrankaRobot.merge_gripper_pads`, called from `add_robot_to_scene` after `_load_robot_spec`. One box over the same span is the same shape to everything outside the gripper, and has no interior boundary to catch anything on.

Applied unconditionally: the seam is in the gripper rather than in any one object, so any thin wall, rim, lid, plate or sheet can reach it, and no caller wants it.

The surviving collider is **`pad2`**, the geom the robot views identify each finger by (`franka_droid_view`, `franka_cap_view`), so the colliding geom keeps the name downstream code expects. Only the local **z** extent changes, so the fingers' separation — and hence `inter_finger_dist` — is untouched.

Verified on the compiled model:

```
before   left_pad1 0.11063..0.12937 contype=1     right_pad1 0.11063..0.12937 contype=1
         left_pad2 0.12938..0.14813 contype=1     right_pad2 0.12938..0.14813 contype=1

after    left_pad1 0.11063..0.12937 contype=0     right_pad1 0.11063..0.12937 contype=0
         left_pad2 0.11063..0.14813 contype=1     right_pad2 0.11063..0.14813 contype=1
```

Each finger merges from its own pair, left and right independently. Jaw travel still reads 6.5–86.8 mm.

## Validation, and its limits

**One task, in the private repo** (turn a paper cup upside down). It went from never succeeding to:

```
498 steps, solved, reward 1.0, 2 grasps, 0 drops
while holding: median 30.5 N, max 105 N over 246 steps
one 7-step spike to 813 N as the jaws close (was a sustained 2703 N trap)
```

**No public benchmark has been run against this.** It changes gripper collision geometry for every Franka+Robotiq consumer, so it deserves a look from someone who can run the public suites.

Arguably the defect belongs in the shipped Robotiq XML rather than being patched at spec-assembly time — the asset is not version-controlled in this repo, so this is the reachable fix, not necessarily the right long-term home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)